### PR TITLE
feat: demo server uses local UI assets

### DIFF
--- a/demo/server.py
+++ b/demo/server.py
@@ -21,7 +21,11 @@ APP_ROOT      = Path(__file__).resolve().parents[1]
 REAL_TEMPLATES= APP_ROOT / "src" / "templates"
 REAL_STATIC   = APP_ROOT / "src" / "static"
 APP_SRC       = APP_ROOT / "src"
-UI_ROOT       = APP_ROOT / "submodules" / "deployable-ui" / "src" / "ui"
+
+# Prefer vendored UI assets but fall back to submodule when available.
+_UI_SUBMODULE = APP_ROOT / "submodules" / "deployable-ui" / "src" / "ui"
+_UI_VENDOR    = APP_ROOT / "src" / "ui"
+UI_ROOT       = _UI_SUBMODULE if (_UI_SUBMODULE / "js").exists() else _UI_VENDOR
 
 app = FastAPI(title="Deployable Web Demo (Fake API)")
 
@@ -348,15 +352,18 @@ def favicon(): return BaseResponse(status_code=204)
 
 @app.get("/health")
 def health():
+    ui_js_dir = UI_ROOT / "js"
+    ui_css_dir = UI_ROOT / "css"
+    ui_assets_dir = UI_ROOT / "assets"
     return {
         "status": "ok",
-        "demo_templates": str(DEMO_TEMPLATES),
-        "demo_static": str(DEMO_STATIC),
-        "ui_js_dir": str(UI_JS_DIR),
-        "ui_css_dir": str(UI_CSS_DIR),
-        "ui_assets_dir": str(UI_ASSETS_DIR),
-        "ui_js_present": UI_JS_DIR.exists(),
-        "ui_css_present": UI_CSS_DIR.exists(),
+        "templates": str(REAL_TEMPLATES),
+        "static": str(REAL_STATIC),
+        "ui_js_dir": str(ui_js_dir),
+        "ui_css_dir": str(ui_css_dir),
+        "ui_assets_dir": str(ui_assets_dir),
+        "ui_js_present": ui_js_dir.exists(),
+        "ui_css_present": ui_css_dir.exists(),
     }
 
 @app.get("/healthz")

--- a/src/ui/css/style.css
+++ b/src/ui/css/style.css
@@ -1,0 +1,1 @@
+/* placeholder for additional styles */

--- a/src/ui/css/theme.css
+++ b/src/ui/css/theme.css
@@ -1,0 +1,1 @@
+/* placeholder theme */

--- a/src/ui/css/ui.css
+++ b/src/ui/css/ui.css
@@ -1,0 +1,6 @@
+/* Minimal styles for demo */
+.list-item { padding:4px; border-bottom:1px solid #243140; }
+.list-item .title { font-weight:600; }
+.list-item .subtitle { font-size:12px; opacity:0.7; }
+.list-item .actions { margin-top:4px; }
+.btn { background:#5ec3ff; color:#001018; border:none; border-radius:6px; padding:2px 6px; cursor:pointer; }

--- a/src/ui/js/components.js
+++ b/src/ui/js/components.js
@@ -1,0 +1,43 @@
+import { el } from './ui.js';
+
+export const bus = new EventTarget();
+
+const registry = new Map(); // winId -> {compId: obj}
+
+export function registerComponent(winId, compId, obj) {
+  if (!registry.has(winId)) registry.set(winId, new Map());
+  registry.get(winId).set(compId, obj);
+}
+
+export function getComponent(winId, compId) {
+  return registry.get(winId)?.get(compId);
+}
+
+export function createItemList(winId, { target, id, keyField = 'id', item_template = {} }) {
+  function render(items = []) {
+    target.innerHTML = '';
+    for (const it of items) {
+      const row = el('div', { class: 'list-item', 'data-key': it[keyField] });
+      const title = item_template.title ? item_template.title(it) : it[keyField];
+      const subtitle = item_template.subtitle ? item_template.subtitle(it) : '';
+      row.appendChild(el('div', { class: 'title' }, [title]));
+      if (subtitle) row.appendChild(el('div', { class: 'subtitle' }, [subtitle]));
+      const actions = item_template.actions || [];
+      if (actions.length) {
+        const actWrap = el('div', { class: 'actions' });
+        actions.forEach((a) => {
+          const btn = el('button', { class: 'btn', type: 'button' }, [a.label]);
+          btn.addEventListener('click', () => {
+            bus.dispatchEvent(new CustomEvent('ui:list-action', {
+              detail: { winId, listId: id, action: a, item: it },
+            }));
+          });
+          actWrap.appendChild(btn);
+        });
+        row.appendChild(actWrap);
+      }
+      target.appendChild(row);
+    }
+  }
+  return { render };
+}

--- a/src/ui/js/ui.js
+++ b/src/ui/js/ui.js
@@ -1,0 +1,46 @@
+export function el(tag, props = {}, children = []) {
+  const elem = document.createElement(tag);
+  for (const [k, v] of Object.entries(props)) {
+    if (k === 'style' && v && typeof v === 'object') {
+      Object.assign(elem.style, v);
+    } else if (k === 'class') {
+      elem.className = v;
+    } else if (k.startsWith('data-')) {
+      elem.setAttribute(k, v);
+    } else if (k in elem) {
+      // e.g. id
+      elem[k] = v;
+    } else {
+      elem.setAttribute(k, v);
+    }
+  }
+  if (!Array.isArray(children)) children = [children];
+  for (const child of children) {
+    if (child == null) continue;
+    if (typeof child === 'string') {
+      elem.appendChild(document.createTextNode(child));
+    } else {
+      elem.appendChild(child);
+    }
+  }
+  return elem;
+}
+
+// Minimal stubs to satisfy existing imports
+export class Field {
+  constructor(element) {
+    this.element = element;
+  }
+}
+
+export function fieldRow(...els) {
+  const row = el('div', { class: 'field-row' });
+  els.forEach((e) => {
+    if (typeof e === 'string') {
+      row.appendChild(document.createTextNode(e));
+    } else if (e) {
+      row.appendChild(e);
+    }
+  });
+  return row;
+}

--- a/src/ui/js/window.js
+++ b/src/ui/js/window.js
@@ -1,0 +1,13 @@
+const registry = new Map();
+
+export function registerWindowType(name, renderer) {
+  registry.set(name, renderer);
+}
+
+export function createWindow(type, cfg = {}, winId) {
+  const renderer = registry.get(type);
+  if (!renderer) throw new Error(`Unknown window type: ${type}`);
+  return renderer(cfg, winId);
+}
+
+export { registry as _registry };


### PR DESCRIPTION
## Summary
- serve fallback UI library from `src/ui` when submodule is absent
- add minimal JS/CSS implementation for UI components, event bus and window registry
- fix `/health` to report real template/static paths

## Testing
- `pip install -r requirements.txt`
- `python -m uvicorn demo.server:app --host 127.0.0.1 --port 8001` (background)
- `curl -sSf http://127.0.0.1:8001/health`


------
https://chatgpt.com/codex/tasks/task_e_689c289944c8832cb600e6521fbbf142