### PR TITLE
fix: remove sessions cleanly

### DIFF
--- a/demo/server.py
+++ b/demo/server.py
@@ -133,6 +133,14 @@ class FileStore:
             except OSError:
                 pass
 
+    def delete(self, sid: str) -> None:
+        """Remove the stored session file if it exists."""
+        p = self._path(sid)
+        try:
+            p.unlink()
+        except FileNotFoundError:
+            pass
+
 class SessionManager:
     def __init__(self, settings: Settings):
         self.settings = settings


### PR DESCRIPTION
## Summary
- implement missing FileStore.delete to remove session files

## Testing
- `python -m py_compile demo/server.py`


------
https://chatgpt.com/codex/tasks/task_e_689c56b23c54832c9be0db7a388d4a06