### PR TITLE
feat: add demo windows for sessions, documents and segments

### DIFF
--- a/src/knowledge_web/static/js/main.js
+++ b/src/knowledge_web/static/js/main.js
@@ -1,297 +1,143 @@
 import { initWindowDnD } from "/static/ui/js/dnd.js";
 import { initSplitter } from "/static/ui/js/splitter.js";
-import { createMiniWindowFromConfig, initWindowResize, mountModal } from "/static/ui/js/window.js";
-import { initMenu } from "/static/ui/js/menu.js";
-import { createUserMenu } from "/static/ui/js/user_menu.js";
-import { getVar, setVar } from "/static/ui/js/theme.js";
+import { createMiniWindowFromConfig, initWindowResize } from "/static/ui/js/window.js";
 
-// Initialise basic UI helpers
+// basic UI initialisation
 initSplitter();
 initWindowDnD();
 initWindowResize();
 
 function spawnWindow(cfg) {
   const node = createMiniWindowFromConfig(cfg);
-  if (cfg.modal) {
-    mountModal(node, { fade: cfg.modalFade !== false });
-  } else {
-    const col = document.getElementById(cfg.col === "right" ? "col-right" : "col-left");
-    col.appendChild(node);
-  }
+  const col = document.getElementById(cfg.col === "right" ? "col-right" : "col-left");
+  col.appendChild(node);
   return node;
 }
 
-const headerRight = document.querySelector(".app-header .right");
-const userMenu = createUserMenu({
-  name: "Demo User",
-  items: [
-    { id: "account", label: "Account Settings", onClick: () => console.log("account") },
-    { id: "appearance", label: "Appearance", onClick: () => spawnAppearanceWindow() },
-    { separator: true },
-    { id: "logout", label: "Logout", onClick: () => console.log("logout") }
-  ]
-});
-headerRight.appendChild(userMenu);
-
-function spawnAppearanceWindow() {
-  const win = spawnWindow({
-    id: `appearance_${counter++}`,
-    window_type: "window_generic",
-    title: "Appearance",
-    col: "right",
-    resizable: true,
-    dockable: true,
-    Elements: [
-      {
-        type: "number_field",
-        id: "theme_h",
-        name: "Hue",
-        min: 0,
-        max: 360,
-        value: parseInt(getVar("--h")) || 220
-      },
-      {
-        type: "number_field",
-        id: "theme_sat",
-        name: "Sat",
-        min: 0,
-        max: 100,
-        value: parseInt(getVar("--sat")) || 18
-      },
-      {
-        type: "number_field",
-        id: "theme_radius",
-        name: "Radius",
-        min: 0,
-        max: 40,
-        value: parseInt(getVar("--radius")) || 16
-      },
-      { type: "submit_button", text: "Apply" }
-    ]
-  });
-
-  const form = win.querySelector("form");
-  const apply = () => {
-    const h = form.querySelector("#theme_h").value;
-    const s = form.querySelector("#theme_sat").value;
-    const r = form.querySelector("#theme_radius").value;
-    setVar("--h", h);
-    setVar("--sat", `${s}%`);
-    setVar("--radius", `${r}px`);
-  };
-  form.addEventListener("change", apply);
-  form.addEventListener("submit", (e) => { e.preventDefault(); apply(); });
+async function apiGet(path) {
+  const res = await fetch(path);
+  if (!res.ok) throw new Error(`request failed: ${path}`);
+  return res.json();
 }
 
-// Seed demo windows
-spawnWindow({
-  id: "win_left",
-  window_type: "window_generic",
-  title: "Left Demo",
-  col: "left",
-  unique: true,
-  resizable: true,
-  Elements: [
-    { type: "text", text: "This is a generic left window." }
-  ]
-});
+let chatWin = null;
 
-spawnWindow({
-  id: "win_right",
-  window_type: "window_generic",
-  title: "Right Demo",
-  col: "right",
-  unique: true,
-  resizable: true,
-  Elements: [
-    { type: "text", text: "This is a generic right window." }
-  ]
-});
+function spawnChatWindow(history = []) {
+  if (chatWin) chatWin.remove();
+  chatWin = spawnWindow({
+    id: "chat_window",
+    window_type: "window_chat",
+    title: "Chat",
+    col: "right",
+    dockable: true,
+    resizable: true,
+    history,
+    onSend: async (text) => ({ role: "assistant", content: `Echo: ${text}` })
+  });
+}
 
-// Simple menu actions to spawn additional windows
-let counter = 0;
-initMenu((action) => {
-  if (action === "spawn-left") {
-    counter++;
-    spawnWindow({
-      id: `left_${counter}`,
-      window_type: "window_generic",
-      title: `Left Window ${counter}`,
-      col: "left",
-      resizable: true,
-      Elements: [{ type: "text", text: `Dynamic left window ${counter}.` }]
-    });
+async function loadSession(sessionId) {
+  const data = await apiGet(`/sessions/${sessionId}`);
+  const history = [];
+  for (const [u, a] of data.history) {
+    history.push({ role: "user", content: u });
+    history.push({ role: "assistant", content: a });
   }
-  if (action === "spawn-right") {
-    counter++;
-    spawnWindow({
-      id: `right_${counter}`,
-      window_type: "window_generic",
-      title: `Right Window ${counter}`,
-      col: "right",
-      resizable: true,
-      Elements: [{ type: "text", text: `Dynamic right window ${counter}.` }]
-    });
-  }
-  if (action === "spawn-dockable-modal") {
-    counter++;
-    spawnWindow({
-      id: `dockable_${counter}`,
-      window_type: "window_generic",
-      title: `Dockable Modal ${counter}`,
-      modal: true,
-      dockable: true,
-      resizable: true,
-      Elements: [{ type: "text", text: "This modal can dock or undock." }]
-    });
-  }
-  if (action === "spawn-simple-modal") {
-    counter++;
-    spawnWindow({
-      id: `modal_${counter}`,
-      window_type: "window_generic",
-      title: `Simple Modal ${counter}`,
-      modal: true,
-      modalFade: false,
-      Elements: [{ type: "text", text: "This modal cannot dock." }]
-    });
-  }
-  if (action === "spawn-showcase") {
-    counter++;
-    const idx = counter;
-    spawnWindow({
-      id: `showcase_${idx}`,
-      window_type: "window_generic",
-      title: `UI Showcase ${idx}`,
-      col: "left",
-      resizable: true,
-      Elements: [
-        {
-          type: "item_list",
-          id: `list_basic_${idx}`,
-          label: "Items",
-          items: [
-            { label: "Item A" },
-            { label: "Item B" },
-            { label: "Item C" }
-          ],
-          item_template: { elements: [{ type: "text", bind: "label" }] }
-        },
-        { type: "text_field", name: "title", label: "Title", placeholder: "Enter title" },
-        { type: "text_area", name: "description", label: "Description" },
-        {
-          type: "select",
-          name: "choice",
-          label: "Choice",
-          options: [
-            { value: "one", label: "One" },
-            { value: "two", label: "Two" },
-            { value: "three", label: "Three" }
+  spawnChatWindow(history);
+}
+
+async function loadSessions() {
+  const sessions = await apiGet("/sessions");
+  spawnWindow({
+    id: "sessions_window",
+    window_type: "window_generic",
+    title: "Sessions",
+    col: "left",
+    resizable: true,
+    Elements: [
+      {
+        type: "list_view",
+        id: "sessions_list",
+        items: sessions,
+        keyField: "session_id",
+        template: {
+          title: (it) => it.title,
+          subtitle: (it) => new Date(it.created_at).toLocaleString(),
+          actions: [
+            { label: "Open", onClick: (item) => loadSession(item.session_id) }
           ]
-        },
-        {
-          type: "multi_select",
-          name: "tags",
-          label: "Tags",
-          options: [
-            { value: "red", label: "Red" },
-            { value: "green", label: "Green" },
-            { value: "blue", label: "Blue" }
+        }
+      }
+    ]
+  });
+}
+
+async function loadDocuments() {
+  const docs = await apiGet("/documents");
+  spawnWindow({
+    id: "documents_window",
+    window_type: "window_generic",
+    title: "Documents",
+    col: "left",
+    resizable: true,
+    Elements: [
+      {
+        type: "list_view",
+        id: "documents_list",
+        items: docs,
+        keyField: "id",
+        template: {
+          title: (it) => it.title,
+          subtitle: (it) => `${it.segments} segments`
+        }
+      }
+    ]
+  });
+}
+
+async function openSegment(id) {
+  const seg = await apiGet(`/segments/${id}`);
+  spawnWindow({
+    id: `segment_${id}`,
+    window_type: "window_text_editor",
+    title: seg.source,
+    col: "right",
+    dockable: true,
+    resizable: true,
+    content: seg.text,
+    onSave: ({ id, content }) => console.log("save", id, content)
+  });
+}
+
+async function loadSegments() {
+  const segs = await apiGet("/segments");
+  spawnWindow({
+    id: "segments_window",
+    window_type: "window_generic",
+    title: "Segments",
+    col: "right",
+    resizable: true,
+    Elements: [
+      {
+        type: "list_view",
+        id: "segments_list",
+        items: segs,
+        keyField: "id",
+        template: {
+          title: (it) => it.source,
+          subtitle: (it) => it.preview,
+          actions: [
+            { label: "Open", onClick: (item) => openSegment(item.id) }
           ]
-        },
-        { type: "submit_button", text: "Save" },
-        {
-          type: "item_list",
-          id: `list_custom_${idx}`,
-          label: "Files",
-          items: [
-            { name: "Report.pdf" },
-            { name: "Chart.png" }
-          ],
-          item_template: {
-            elements: [
-              { type: "text", bind: "name" },
-              { type: "button", label: "Open", action: "open" },
-              { type: "button", label: "Remove", action: "remove", variant: "danger" }
-            ]
-          }
         }
-      ]
-    });
-  }
-  if (action === "spawn-editor") {
-    counter++;
-    spawnWindow({
-      id: `editor_${counter}`,
-      window_type: "window_text_editor",
-      title: `Editor ${counter}`,
-      col: "left",
-      dockable: true,
-      resizable: true,
-      content: "Type here...",
-      onSave: ({ id, content }) => console.log("save", id, content)
-    });
-  }
-  if (action === "spawn-listview") {
-    counter++;
-    spawnWindow({
-      id: `listview_${counter}`,
-      window_type: "window_generic",
-      title: `List View ${counter}`,
-      col: "right",
-      resizable: true,
-      Elements: [
-        {
-          type: "list_view",
-          id: `lv_${counter}`,
-          items: [
-            { id: 1, name: "Alpha", role: "admin" },
-            { id: 2, name: "Beta", role: "user" },
-            { id: 3, name: "Gamma", role: "guest" }
-          ],
-          keyField: "id",
-          template: {
-            title: (it) => it.name,
-            subtitle: (it) => it.role,
-            actions: [
-              { label: "Ping", onClick: (item) => console.log("ping", item.name) }
-            ]
-          },
-          selectable: true,
-          onSelectChange: (sel) => console.log("select", sel)
-        }
-      ]
-    });
-  }
-  if (action === "spawn-chat") {
-    counter++;
-    spawnWindow({
-      id: `chat_${counter}`,
-      window_type: "window_chat",
-      title: `Chat ${counter}`,
-      col: "left",
-      dockable: true,
-      resizable: true,
-      onSend: async (text) => ({ role: "assistant", content: `Echo: ${text}` })
-    });
-  }
-  if (action === "spawn-upload") {
-    counter++;
-    spawnWindow({
-      id: `upload_${counter}`,
-      window_type: "window_generic",
-      title: `Upload ${counter}`,
-      col: "right",
-      resizable: true,
-      Elements: [
-        {
-          type: "file_upload",
-          id: `fu_${counter}`,
-          multiple: true,
-          buttonLabel: "Upload",
-          onUpload: (files) => console.log("upload", files)
-        }
-      ]
-    });
-  }
-});
+      }
+    ]
+  });
+}
+
+// initial windows
+spawnChatWindow();
+loadSessions();
+loadDocuments();
+loadSegments();
+

--- a/src/knowledge_web/templates/pages/index.html
+++ b/src/knowledge_web/templates/pages/index.html
@@ -3,33 +3,15 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Deployable UI Demo</title>
+  <title>Deployable Knowledge Web</title>
   <link rel="stylesheet" href="/static/ui/css/theme.css" />
   <link rel="stylesheet" href="/static/ui/css/style.css" />
 </head>
 <body>
   <div class="app">
     <div class="app-header">
-      <div class="left">
-        <div class="menu">
-          <button id="menu-trigger" class="menu-trigger" aria-haspopup="true" aria-expanded="false">Menu ▾</button>
-          <div id="menu-dropdown" class="menu-dropdown" role="menu" aria-hidden="true">
-            <button class="menu-item" data-action="spawn-left" role="menuitem">New Left Window</button>
-            <button class="menu-item" data-action="spawn-right" role="menuitem">New Right Window</button>
-            <div class="menu-sep"></div>
-            <button class="menu-item" data-action="spawn-dockable-modal" role="menuitem">Dockable Modal</button>
-            <button class="menu-item" data-action="spawn-simple-modal" role="menuitem">Simple Modal</button>
-            <div class="menu-sep"></div>
-            <button class="menu-item" data-action="spawn-showcase" role="menuitem">UI Showcase</button>
-            <div class="menu-sep"></div>
-            <button class="menu-item" data-action="spawn-editor" role="menuitem">Text Editor</button>
-            <button class="menu-item" data-action="spawn-listview" role="menuitem">List View Demo</button>
-            <button class="menu-item" data-action="spawn-chat" role="menuitem">Chat</button>
-            <button class="menu-item" data-action="spawn-upload" role="menuitem">File Upload Demo</button>
-          </div>
-        </div>
-      </div>
-      <div class="brand"><strong>Deployable UI Demo</strong></div>
+      <div class="left"></div>
+      <div class="brand"><strong>Deployable Knowledge Web</strong></div>
       <div class="right"></div>
     </div>
 


### PR DESCRIPTION
## Summary
- replace demo page layout with streamlined header
- add JS to fetch sessions, documents and segments and show them in windows
- wire session list to update chat window and open segments in editor

## Testing
- `python3 -m py_compile demo/server.py`
- `make smoke` *(fails: health: FAIL)*

------
https://chatgpt.com/codex/tasks/task_e_689c66bdaa54832cb6431a0505c4e997