### PR TITLE
refactor: adopt deployable-ui chat window

### DIFF
--- a/src/knowledge_web/static/app/css/theme.css
+++ b/src/knowledge_web/static/app/css/theme.css
@@ -1,0 +1,55 @@
+/* === THEME SYSTEM ===
+   Change --h to recolor the whole UI.
+   Examples: blue=220, purple=270, green=150, red=10, gray=220 + low --sat
+*/
+:root {
+  --h: 220;          /* base hue */
+  --sat: 18%;        /* global saturation bias */
+  --txt: 92%;        /* text lightness */
+
+  /* Layout & typography */
+  --titlebar-height: 36px;
+  --font-size-base: 14px;
+  --font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, "Helvetica Neue", Arial, sans-serif;
+  --win-gap-vertical: 6px;
+  --win-gap-horizontal: 8px;
+
+  --positive-h: 150;
+  --negative-h: 10;
+  --neutral-h: calc((var(--positive-h) + var(--negative-h)) / 2 + 180);
+
+  /* Base lightness stops (dark theme) */
+  --l-bg: 7%;
+  --l-panel: 11%;
+  --l-elev: 16%;
+  --l-border: 20%;
+  --l-muted: 65%;
+
+  /* Derived palette */
+  --base-color: hsl(var(--h) var(--sat) var(--l-panel));
+  --bg:        hsl(var(--h) var(--sat) var(--l-bg));
+  --panel:     var(--base-color);
+  --elev:      hsl(var(--h) var(--sat) var(--l-elev));
+  --panel-sel: hsl(var(--h) var(--sat) calc(var(--l-panel) + 6%));
+  --text:      hsl(var(--h) calc(var(--sat) * 2) var(--txt));
+  --muted:     hsl(var(--h) 12% var(--l-muted));
+  --border:    hsl(var(--h) 18% var(--l-border));
+
+  /* Accents */
+  --positive-accent: hsl(var(--positive-h) 60% 55%);
+  --negative-accent: hsl(var(--negative-h) 60% 55%);
+  --neutral-accent: hsl(var(--neutral-h) 60% 55%);
+  --accent: var(--positive-accent);
+  --accent-2: var(--neutral-accent);
+
+  --shadow: 0 10px 30px rgba(0,0,0,.35), 0 2px 6px rgba(0,0,0,.25);
+  --win-radius: 16px;
+  --backdrop: rgba(2, 6, 12, .55);
+}
+
+/* Optional pre-baked themes: add class to <html> or <body> */
+.theme-purple { --h: 270; }
+.theme-green  { --h: 150; }
+.theme-red    { --h: 10;  }
+.theme-gray   { --h: 220; --sat: 6%; }
+

--- a/src/knowledge_web/static/app/js/windows/chat.js
+++ b/src/knowledge_web/static/app/js/windows/chat.js
@@ -1,64 +1,108 @@
-import { createChatWindow as createUiChatWindow } from "/static/ui/js/windows/chat.js";
+// chat.js — streaming via HTMLElement placeholder (no framework changes)
+import { spawnWindow } from "/static/ui/js/framework.js";
 import { chat, chatStream } from "../sdk.js";
 import { Store } from "../store.js";
 import { md, htmlEscape } from "../util.js";
 
 export function createChatWindow() {
-  const ui = createUiChatWindow({ title: "Assistant Chat" });
+  return spawnWindow({
+    id: "win_chat",
+    window_type: "window_chat",
+    title: "Assistant Chat",
+    col: "right",
+    unique: true,
+    dockable: true,
+    resizable: true,
 
-  ui.onSend = async (text, bubble) => {
-    try {
-      const { reader, decoder } = await chatStream({
-        message: text,
-        session_id: (Store.sessionId || "") + "",
-        persona: Store.persona || "",
-        inactive: Store.inactiveList?.() || [],
-      });
-      let buf = "";
-      let acc = "";
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buf += decoder.decode(value, { stream: true });
-        const chunks = buf.split("\n\n");
-        buf = chunks.pop();
-        for (const chunk of chunks) {
-          let event = "delta", data = "";
-          for (const line of chunk.split("\n")) {
-            if (line.startsWith("event:")) event = line.slice(6).trim();
-            else if (line.startsWith("data:")) data += line.slice(5).trim();
-          }
-          if (event === "delta") {
-            let parsed;
-            try { parsed = JSON.parse(data); } catch {}
-            if (parsed !== undefined) {
-              if (typeof parsed === "object" && parsed) {
-                data = parsed.delta ?? parsed.response ?? Object.values(parsed)[0] ?? "";
-              } else {
-                data = parsed + "";
-              }
-            }
-            if (data === "." || data === "[DONE]") continue;
-            acc += data;
-            bubble.innerHTML = md(acc);
-          }
-        }
-      }
-    } catch {
+    // NOTE: window_chat calls onSend(text, ctx)
+    // ctx.append({ role, content }) accepts an HTMLElement for content.
+    onSend: async (text, ctx) => {
+      // 1) Create an empty assistant bubble immediately
+      const placeholder = document.createElement("div");
+      placeholder.className = "markdown"; // so your CSS/markdown renderer styles apply
+      ctx.append({ role: "assistant", content: placeholder });
+
+      // small helper to keep log scrolled to bottom while streaming
+      const chatLog = placeholder.closest(".chat-log");
+      const autoscroll = () => {
+        if (chatLog) chatLog.scrollTop = chatLog.scrollHeight;
+      };
+
+      // 2) Try streaming first
       try {
-        const res = await chat({
+        const { reader, decoder } = await chatStream({
           message: text,
           session_id: (Store.sessionId || "") + "",
           persona: Store.persona || "",
           inactive: Store.inactiveList?.() || [],
         });
-        bubble.innerHTML = md(res.response ?? "(no response)");
-      } catch (e2) {
-        bubble.innerHTML = `<em>Error:</em> ${htmlEscape(e2.message)}`;
+
+        let buf = "";
+        let acc = "";
+
+        // paint something right away so the user sees the bubble
+        placeholder.innerHTML = "";
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+
+          buf += decoder.decode(value, { stream: true });
+
+          // split Server-Sent-Events style chunks by double newline
+          const chunks = buf.split("\n\n");
+          buf = chunks.pop(); // keep partial for next read
+
+          for (const chunk of chunks) {
+            let event = "delta";
+            let data = "";
+
+            for (const line of chunk.split("\n")) {
+              if (line.startsWith("event:")) event = line.slice(6).trim();
+              else if (line.startsWith("data:")) data += line.slice(5).trim();
+            }
+            if (event !== "delta") continue;
+
+            // be liberal: accept plain text or JSON {delta:"..."} / {response:"..."}
+            let textDelta = "";
+            try {
+              const parsed = JSON.parse(data);
+              if (parsed && typeof parsed === "object") {
+                textDelta = parsed.delta ?? parsed.response ?? "";
+              } else {
+                textDelta = String(parsed ?? "");
+              }
+            } catch {
+              textDelta = data;
+            }
+            if (textDelta === "." || textDelta === "[DONE]") continue;
+
+            acc += textDelta;
+            placeholder.innerHTML = md(acc);
+            autoscroll();
+          }
+        }
+
+        // We already wrote the assistant content; returning nothing prevents a duplicate bubble
+        return;
+      } catch (streamErr) {
+        // 3) Fallback to one-shot (non-streaming) request
+        try {
+          const res = await chat({
+            message: text,
+            session_id: (Store.sessionId || "") + "",
+            persona: Store.persona || "",
+            inactive: Store.inactiveList?.() || [],
+          });
+          placeholder.innerHTML = md(res.response ?? "(no response)");
+          autoscroll();
+          return; // don't return a message object (we already rendered it)
+        } catch (e2) {
+          placeholder.innerHTML = `<em>Error:</em> ${htmlEscape(e2.message)}`;
+          autoscroll();
+          return;
+        }
       }
-    }
-  };
-
-  return ui;
+    },
+  });
 }
-

--- a/src/knowledge_web/templates/index.html
+++ b/src/knowledge_web/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Deployable Knowledge v0.1</title>
-  <link rel="stylesheet" href="/static/ui/css/theme.css" />
+  <link rel="stylesheet" href="/static/app/css/theme.css" />
   <link rel="stylesheet" href="/static/ui/css/style.css" />
   <link rel="icon" href="data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%231b2130'/%3E%3Cpath d='M16 40 L32 16 L48 40' stroke='%236aa8ff' stroke-width='6' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E" />
 </head>


### PR DESCRIPTION
## Summary
- replace custom chat window with deployable-ui standard chat window
- retain streaming/fallback logic while delegating UI to shared component

## Testing
- `make smoke` *(fails: health: FAIL)*

------
https://chatgpt.com/codex/tasks/task_e_689f208837dc832cb60b142f8ff125a1