### PR TITLE
Add editor and settings windows with default layout

### DIFF
--- a/src/knowledge_web/static/app/css/theme.css
+++ b/src/knowledge_web/static/app/css/theme.css
@@ -53,3 +53,7 @@
 .theme-red    { --h: 10;  }
 .theme-gray   { --h: 220; --sat: 6%; }
 
+#columns {
+  grid-template-columns: 1fr 4px 3fr;
+}
+

--- a/src/knowledge_web/static/app/js/main.js
+++ b/src/knowledge_web/static/app/js/main.js
@@ -1,5 +1,5 @@
 // /app/main.js
-import { initFramework, spawnWindow  } from "/static/ui/js/framework.js";
+import { initFramework } from "/static/ui/js/framework.js";
 import { bus } from "/static/ui/js/components.js";
 import { Store } from "./store.js";
 import { createChatWindow } from "./windows/chat.js";
@@ -9,9 +9,22 @@ import { createSearchWindow } from "./windows/search.js";
 import { openSessionsWindow, loadChatHistory } from "./windows/sessions.js";
 
 import { openPersonaEditor } from "./windows/persona.js";
+import { openPromptEditor } from "./windows/prompt.js";
+import { openLLMSettings } from "./windows/llm.js";
 import { initMenu } from "/static/ui/js/menu.js";
 
+async function openUISettings() {
+  const mod = await import("/static/ui/js/windows/ui_settings.js");
+  mod.openUISettings();
+}
+
 initFramework();
+
+function setDefaultLayout() {
+  const cols = document.getElementById("columns");
+  if (cols) cols.style.gridTemplateColumns = "1fr 4px 3fr";
+}
+setDefaultLayout();
 
 async function ensureChatSession() {
   try {
@@ -51,25 +64,18 @@ function registerBusHandlers() {
 
 
 // Header “Menu ▾”
-initMenu(async (action) => {
-  if (action === "new-chat") {
-    Store.sessionId = await api.startNewSession();
-    initSessionsController("win_sessions");
-  }
+initMenu((action) => {
   if (action === "toggle-search") {
-    const id = "win_search";
-    const existing = document.getElementById(id);
+    const existing = document.getElementById("win_search");
     if (existing) {
       existing.remove();
     } else {
-      spawnWindow({ id, window_type: "window_search", title: "Search Documents", col: "right", unique: true });
-      initSearchController(id);
-      if (Store.lastQuery) runSearch(Store.lastQuery, id);
+      createSearchWindow();
     }
   }
-  if (action === "edit-persona") openPersonaModal();
-  if (action === "settings")     openSettingsModal();
   if (action === "prompt-templates") openPromptEditor();
+  if (action === "settings") openUISettings();
+  if (action === "llm-settings") openLLMSettings();
 });
 
 // Header “User ▾”
@@ -80,19 +86,23 @@ initMenu((action) => {
 // “Tools ▾”
 initMenu((action) => {
   if (action === "tool-chat") {
-    spawnWindow({ id: "win_chat", window_type: "window_chat_ui", title: "Assistant Chat", col: "right", unique: true });
-    initChatController();
+    createChatWindow();
   }
   if (action === "tool-docs") {
-    spawnWindow({ id: "win_docs", window_type: "window_documents", title: "Document Library", col: "left", unique: true });
-    initDocsController("win_docs");
+    createDocsWindow();
   }
   if (action === "tool-sessions") {
-   openSessionsWindow();              
+    openSessionsWindow();
+  }
+  if (action === "tool-persona") {
+    openPersonaEditor();
   }
   if (action === "tool-segments") {
-    spawnWindow({ id: "win_segments", window_type: "window_segments", title: "DB Segments", col: "right", unique: true });
-    initSegmentsController("win_segments");
+    createSegmentsWindow();
+  }
+  if (action === "tool-refresh") {
+    refreshDocs();
+    refreshSegments();
   }
 }, "tools-menu-trigger", "tools-menu-dropdown");
 
@@ -103,6 +113,7 @@ const chatUI = createChatWindow();
 createSearchWindow();
 createDocsWindow();
 createSegmentsWindow();
+await openSessionsWindow();
 registerBusHandlers();
 await refreshDocs();
 await refreshSegments();

--- a/src/knowledge_web/static/app/js/sdk.js
+++ b/src/knowledge_web/static/app/js/sdk.js
@@ -54,12 +54,13 @@ export async function removeSegment(id) {
   return await res.json();
 }
 // --- chat (non-stream) ---
-export async function chat({ message, session_id, persona = "", inactive = [] }) {
+export async function chat({ message, session_id, persona = "", inactive = [], model = "" }) {
   const fd = new FormData();
   fd.append("message", message);
   fd.append("session_id", session_id);
   fd.append("persona", persona);
   fd.append("inactive", JSON.stringify(inactive));
+  if (model) fd.append("model", model);
   const res = await fetch(`/chat?stream=false`, {
     method: "POST",
     body: fd,
@@ -71,12 +72,13 @@ export async function chat({ message, session_id, persona = "", inactive = [] })
 }
 
 // --- chat (streaming SSE-ish via fetch body reader) ---
-export async function chatStream({ message, session_id, persona = "", inactive = [] }) {
+export async function chatStream({ message, session_id, persona = "", inactive = [], model = "" }) {
   const params = new URLSearchParams();
   params.set("message", message);
   params.set("session_id", session_id);
   params.set("persona", persona);
   if (inactive?.length) params.set("inactive", JSON.stringify(inactive));
+  if (model) params.set("model", model);
 
   const res = await fetch(`/chat?stream=true`, {
     method: "POST",

--- a/src/knowledge_web/static/app/js/store.js
+++ b/src/knowledge_web/static/app/js/store.js
@@ -4,6 +4,8 @@ const state = {
   inactiveDocs: new Set(stored ? JSON.parse(stored) : []),
   sessionId: null,
   persona: localStorage.getItem("persona") || "",
+  prompt: localStorage.getItem("prompt") || "",
+  model: localStorage.getItem("model") || "",
 };
 
 export const Store = {
@@ -11,6 +13,10 @@ export const Store = {
   set sessionId(id) { state.sessionId = id; },
   get persona() { return state.persona; },
   set persona(p) { state.persona = p; localStorage.setItem("persona", p); },
+  get prompt() { return state.prompt; },
+  set prompt(p) { state.prompt = p; localStorage.setItem("prompt", p); },
+  get model() { return state.model; },
+  set model(m) { state.model = m; localStorage.setItem("model", m); },
   inactiveList() { return [...state.inactiveDocs]; },
   isDocActive(id) { return !state.inactiveDocs.has(id); },
   toggleDoc(id) {

--- a/src/knowledge_web/static/app/js/windows/chat.js
+++ b/src/knowledge_web/static/app/js/windows/chat.js
@@ -35,6 +35,7 @@ export function createChatWindow() {
           session_id: (Store.sessionId || "") + "",
           persona: Store.persona || "",
           inactive: Store.inactiveList?.() || [],
+          model: Store.model || "",
         });
 
         let buf = "";
@@ -93,6 +94,7 @@ export function createChatWindow() {
             session_id: (Store.sessionId || "") + "",
             persona: Store.persona || "",
             inactive: Store.inactiveList?.() || [],
+            model: Store.model || "",
           });
           placeholder.innerHTML = md(res.response ?? "(no response)");
           autoscroll();

--- a/src/knowledge_web/static/app/js/windows/llm.js
+++ b/src/knowledge_web/static/app/js/windows/llm.js
@@ -1,33 +1,38 @@
 import { spawnWindow } from "/static/ui/js/framework.js";
 import { Store } from "../store.js";
 
-export function openPersonaEditor() {
-  if (document.getElementById("modal_persona")) return;
+const MODEL_OPTIONS = [
+  { value: "gpt-3.5-turbo", label: "GPT-3.5 Turbo" },
+  { value: "gpt-4", label: "GPT-4" }
+];
+
+export function openLLMSettings() {
+  if (document.getElementById("modal_llm")) return;
   spawnWindow({
-    id: "modal_persona",
+    id: "modal_llm",
     window_type: "window_generic",
-    title: "Persona",
+    title: "LLM Settings",
     modal: true,
     unique: true,
     resizable: false,
     Elements: [
-      { type: "text_area", id: "persona_text", rows: 6, value: Store.persona || "" }
+      { type: "select", id: "model_select", label: "Model", options: MODEL_OPTIONS, value: Store.model || MODEL_OPTIONS[0].value }
     ]
   });
-  const modal = document.getElementById("modal_persona");
+  const modal = document.getElementById("modal_llm");
   const content = modal?.querySelector(".content");
   const actions = document.createElement("div");
   actions.className = "actions";
   const btn = document.createElement("button");
   btn.type = "button";
   btn.className = "btn";
-  btn.id = "persona_save";
+  btn.id = "model_save";
   btn.textContent = "Save";
   actions.appendChild(btn);
   content?.appendChild(actions);
   btn.addEventListener("click", () => {
-    const val = modal.querySelector("#persona_text")?.value || "";
-    Store.persona = val;
+    const val = modal.querySelector("#model_select")?.value || "";
+    Store.model = val;
     const closer =
       modal.querySelector("[data-action='close'], .close, .btn-close, .window-close");
     if (closer) {

--- a/src/knowledge_web/static/app/js/windows/prompt.js
+++ b/src/knowledge_web/static/app/js/windows/prompt.js
@@ -1,33 +1,33 @@
 import { spawnWindow } from "/static/ui/js/framework.js";
 import { Store } from "../store.js";
 
-export function openPersonaEditor() {
-  if (document.getElementById("modal_persona")) return;
+export function openPromptEditor() {
+  if (document.getElementById("modal_prompt")) return;
   spawnWindow({
-    id: "modal_persona",
+    id: "modal_prompt",
     window_type: "window_generic",
-    title: "Persona",
+    title: "Prompt Templates",
     modal: true,
     unique: true,
     resizable: false,
     Elements: [
-      { type: "text_area", id: "persona_text", rows: 6, value: Store.persona || "" }
+      { type: "text_area", id: "prompt_text", rows: 6, value: Store.prompt || "" }
     ]
   });
-  const modal = document.getElementById("modal_persona");
+  const modal = document.getElementById("modal_prompt");
   const content = modal?.querySelector(".content");
   const actions = document.createElement("div");
   actions.className = "actions";
   const btn = document.createElement("button");
   btn.type = "button";
   btn.className = "btn";
-  btn.id = "persona_save";
+  btn.id = "prompt_save";
   btn.textContent = "Save";
   actions.appendChild(btn);
   content?.appendChild(actions);
   btn.addEventListener("click", () => {
-    const val = modal.querySelector("#persona_text")?.value || "";
-    Store.persona = val;
+    const val = modal.querySelector("#prompt_text")?.value || "";
+    Store.prompt = val;
     const closer =
       modal.querySelector("[data-action='close'], .close, .btn-close, .window-close");
     if (closer) {

--- a/src/knowledge_web/templates/index.html
+++ b/src/knowledge_web/templates/index.html
@@ -19,6 +19,7 @@
             <button class="menu-item" data-action="toggle-search" role="menuitem">Context</button>
             <div class="menu-sep"></div>
             <button class="menu-item" data-action="prompt-templates" role="menuitem">Prompt Templates</button>
+            <button class="menu-item" data-action="llm-settings" role="menuitem">LLM Settings</button>
             <button class="menu-item" data-action="settings" role="menuitem">Settings…</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add prompt, persona, and LLM settings windows wired to menu
- open chat history by default and set 1/4–3/4 column layout
- pass model selection through chat requests and persist in store
- fix window config errors by loading UI settings from framework and creating save buttons via DOM
- use standard Save buttons and close modals cleanly to clear overlays

## Testing
- `node --check src/knowledge_web/static/app/js/windows/prompt.js`
- `node --check src/knowledge_web/static/app/js/windows/persona.js`
- `node --check src/knowledge_web/static/app/js/windows/llm.js`
- `node --check src/knowledge_web/static/app/js/main.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f6e9357c8832caa4549b62a24faaf