### PR TITLE
Fix segment viewer window to load segment data

### DIFF
--- a/src/knowledge_web/static/app/js/windows/segments.js
+++ b/src/knowledge_web/static/app/js/windows/segments.js
@@ -51,7 +51,10 @@ export async function handleSegmentAction(action, item) {
 export async function openSegmentViewer(id) {
   const seg = await getSegment(id);
   const winId = `seg_view_${id}`;
-  spawnWindow({
+  // ``spawnWindow`` may adjust the element's id to avoid collisions.
+  // Capture the returned node so we always reference the correct window
+  // regardless of any internal id renaming.
+  const win = spawnWindow({
     id: winId,
     window_type: "window_generic",
     title: seg?.source ? `Segment • ${seg.source}` : "Segment",
@@ -62,7 +65,6 @@ export async function openSegmentViewer(id) {
       { type: "text", id: "seg_content", value: "" }
     ]
   });
-  const win = document.getElementById(winId);
   const row = win?.querySelector("#seg_content")?.closest(".row");
   if (row) {
     const viewer = document.createElement("div");

--- a/src/knowledge_web/static/app/js/windows/segments.js
+++ b/src/knowledge_web/static/app/js/windows/segments.js
@@ -65,19 +65,19 @@ export async function openSegmentViewer(id) {
       { type: "text", id: "seg_content", value: "" }
     ]
   });
-  const row = win?.querySelector("#seg_content")?.closest(".row");
-  if (row) {
+  const placeholder = win?.querySelector("#seg_content");
+  if (placeholder) {
     const viewer = document.createElement("div");
     viewer.className = "segment-view";
     viewer.innerHTML = `
       <div class="kv">
-        <div><strong>ID:</strong> ${htmlEscape(seg.id||"")}</div>
-        <div><strong>Source:</strong> ${htmlEscape(seg.source||"")}</div>
+        <div><strong>ID:</strong> ${htmlEscape(seg.id || "")}</div>
+        <div><strong>Source:</strong> ${htmlEscape(seg.source || "")}</div>
         <div><strong>Index:</strong> ${htmlEscape(String(seg.segment_index ?? ""))}</div>
-        <div><strong>Priority:</strong> ${htmlEscape(seg.priority||"")}</div>
+        <div><strong>Priority:</strong> ${htmlEscape(seg.priority || "")}</div>
         <div><strong>Chars:</strong> ${htmlEscape(String(seg.start_char ?? ""))}–${htmlEscape(String(seg.end_char ?? ""))}</div>
       </div>
       <div class="prose">${md(seg.text || seg.preview || "(empty)")}</div>`;
-    row.replaceWith(viewer);
+    placeholder.replaceWith(viewer);
   }
 }


### PR DESCRIPTION
## Summary
- ensure segment viewer uses the window element returned by `spawnWindow`
- fixes segment details not rendering when opening a segment

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fb9fd9dfc832cb589552d943e1998