### PR TITLE
feat: modal LLM service settings using backend API

### DIFF
--- a/src/knowledge_web/static/app/js/sdk.js
+++ b/src/knowledge_web/static/app/js/sdk.js
@@ -158,7 +158,8 @@ function uuid() {
 const LLM_LS_SERVICES = "llm.services";
 const LLM_LS_MODELS = "llm.models";
 const LLM_LS_SELECTION = "llm.selection";
-const LLM_USE_MOCK = (localStorage.getItem("llm.mock") || "true") === "true";
+// Default to using the real API unless explicitly overridden via localStorage
+const LLM_USE_MOCK = (localStorage.getItem("llm.mock") || "false") === "true";
 
 function seedMock() {
   if (!LLM_USE_MOCK) return;


### PR DESCRIPTION
## Summary
- show LLM services in a modal pop-out using framework list component
- support open/edit/delete actions and service creation via modal forms
- default SDK to use backend LLM API instead of local mock

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d1980690832c938bf1d6dadf7a8d