### PR TITLE
Refactor UI windows into separate modules

### DIFF
--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -3,6 +3,11 @@ import { DKClient, ensureChatSessionId } from "/static/js/sdk.js";
 import { initDocumentsWindow } from "./windows/documents.js";
 import { initSegmentsWindow } from "./windows/segments.js";
 import { initLLMServicesWindows } from "./windows/llm_services.js";
+import { initChatWindow } from "./windows/chat.js";
+import { initSessionsWindow } from "./windows/sessions.js";
+import { initSearchWindow } from "./windows/search.js";
+import { initPersonaWindow } from "./windows/persona.js";
+import { initTemplatesWindow } from "./windows/templates.js";
 
 // ---- SDK SETUP ----
 const API_BASE = `${location.protocol}//${location.hostname}:8000`;
@@ -38,134 +43,15 @@ window.addEventListener("DOMContentLoaded", async () => {
   initFramework();
   // ... after session/persona init
 
-  initDocumentsWindow({ sdk, sessionId, persona, spawnWindow });
-  initSegmentsWindow({ sdk, sessionId, persona, spawnWindow });
-  // 🔑 make sure user session cookie exists before anything else
+  initDocumentsWindow({ sdk, spawnWindow });
+  initSegmentsWindow({ sdk, spawnWindow });
+  // make sure user session cookie exists before anything else
   await sdk.auth.beginUser();
 
-  // ... 👇 all your existing spawnWindow logic remains unchanged ...
-  spawnWindow({
-    id: "win_chat",
-    title: "Chat",
-    col: "right",
-    window_type: "window_chat",
-    onSend: async (text) => {
-      const out = await sdk.chat.send({ sessionId, message: text, persona });
-      return { role: "assistant", content: out.response };
-    }
-  });
-  
-  // Chat history window
-  spawnWindow({
-    id: "win_history",
-    title: "Chat Sessions",
-    col: "left",
-    window_type: "window_generic",
-    Elements: [
-      { type: "list_view", id: "session_list", items: [], template: { title: it => it.id } }
-    ]
-  });
-  async function refreshSessions() {
-    const items = await sdk.sessions.list();
-    document.getElementById("session_list").update({ items, template: { title: it => it.id } });
-  }
-  refreshSessions();
-
-  // // Document library window
-  // spawnWindow({
-  //   id: "win_docs",
-  //   title: "Document Library",
-  //   col: "left",
-  //   window_type: "window_generic",
-  //   Elements: [
-  //     { type: "file_upload", id: "doc_upload", label: "Upload", multiple: true,
-  //       onUpload: async (files) => { await sdk.ingest.upload(files); refreshDocs(); } },
-  //     { type: "list_view", id: "doc_list", items: [], template: { title: d => d.title, subtitle: d => `segments: ${d.segments}` } }
-  //   ]
-  // });
-  // async function refreshDocs() {
-  //   const docs = await sdk.documents.list();
-  //   document.getElementById("doc_list").update({ items: docs });
-  // }
-  // refreshDocs();
-
-  // // DB Segments window
-  // spawnWindow({
-  //   id: "win_segments",
-  //   title: "DB Segments",
-  //   col: "left",
-  //   window_type: "window_generic",
-  //   Elements: [
-  //     { type: "list_view", id: "seg_list", items: [], template: { title: s => s.id, subtitle: s => s.source } }
-  //   ]
-  // });
-  // async function refreshSegments() {
-  //   const segs = await sdk.segments.list();
-  //   document.getElementById("seg_list").update({ items: segs });
-  // }
-  // refreshSegments();
-
-  // Semantic search window
-  spawnWindow({
-    id: "win_search",
-    title: "Semantic Search",
-    col: "right",
-    window_type: "window_generic",
-    Elements: [
-      { type: "text_field", id: "search_q", label: "Query", placeholder: "Search..." },
-      { type: "submit_button", id: "search_run", text: "Search" },
-      { type: "list_view", id: "search_results", items: [], template: { title: r => r.source, subtitle: r => String(r.score) } }
-    ]
-  });
-  document.getElementById("search_run").addEventListener("click", async () => {
-    const q = document.getElementById("search_q").value;
-    const res = await sdk.search.run({ q });
-    document.getElementById("search_results").update({ items: res.results || [] });
-  });
-
-  // Persona editor window
-  spawnWindow({
-    id: "win_persona",
-    title: "Persona Editor",
-    col: "right",
-    window_type: "window_generic",
-    Elements: [
-      { type: "text_area", id: "persona_text", label: "Persona", placeholder: "You are a helpful assistant." }
-    ]
-  });
-  document.getElementById("persona_text").addEventListener("input", (e) => {
-    persona = e.target.value;
-  });
-
-  // Prompt template editor
-  spawnWindow({
-    id: "win_templates",
-    title: "Prompt Templates",
-    col: "right",
-    window_type: "window_generic",
-    Elements: [
-      { type: "list_view", id: "tpl_list", items: [], template: { title: t => t.id, subtitle: t => t.name } },
-      { type: "text_field", id: "tpl_id", label: "ID" },
-      { type: "text_field", id: "tpl_name", label: "Name" },
-      { type: "text_area", id: "tpl_user", label: "User Format" },
-      { type: "text_area", id: "tpl_system", label: "System Prompt" },
-      { type: "submit_button", id: "tpl_save", text: "Save" }
-    ]
-  });
-  async function refreshTemplates() {
-    const tpls = await sdk.templates.list();
-    document.getElementById("tpl_list").update({ items: tpls });
-  }
-  refreshTemplates();
-  document.getElementById("tpl_save").addEventListener("click", async () => {
-    const id = document.getElementById("tpl_id").value;
-    const name = document.getElementById("tpl_name").value;
-    const user_format = document.getElementById("tpl_user").value;
-    const system = document.getElementById("tpl_system").value;
-    if (id) {
-      await sdk.templates.put(id, { id, name, user_format, system });
-      refreshTemplates();
-    }
-  });
-initLLMServicesWindows({ sdk, spawnWindow });
+  initChatWindow({ sdk, sessionId, getPersona: () => persona, spawnWindow });
+  initSessionsWindow({ sdk, spawnWindow });
+  initSearchWindow({ sdk, spawnWindow });
+  initPersonaWindow({ spawnWindow, initialPersona: persona, onChange: (v) => { persona = v; } });
+  initTemplatesWindow({ sdk, spawnWindow });
+  initLLMServicesWindows({ sdk, spawnWindow });
 });

--- a/src/static/js/windows/chat.js
+++ b/src/static/js/windows/chat.js
@@ -1,0 +1,19 @@
+// applications/windows/chat.js
+export function initChatWindow({ sdk, sessionId, getPersona, spawnWindow }) {
+  if (typeof spawnWindow !== "function") throw new Error("spawnWindow missing");
+
+  spawnWindow({
+    id: "win_chat",
+    title: "Chat",
+    col: "right",
+    window_type: "window_chat",
+    onSend: async (text) => {
+      const out = await sdk.chat.send({
+        sessionId,
+        message: text,
+        persona: typeof getPersona === "function" ? getPersona() : "",
+      });
+      return { role: "assistant", content: out.response };
+    },
+  });
+}

--- a/src/static/js/windows/persona.js
+++ b/src/static/js/windows/persona.js
@@ -1,0 +1,20 @@
+// applications/windows/persona.js
+export function initPersonaWindow({ spawnWindow, initialPersona = "", onChange }) {
+  if (typeof spawnWindow !== "function") throw new Error("spawnWindow missing");
+
+  spawnWindow({
+    id: "win_persona",
+    title: "Persona Editor",
+    col: "right",
+    window_type: "window_generic",
+    Elements: [
+      { type: "text_area", id: "persona_text", label: "Persona", placeholder: "You are a helpful assistant." }
+    ]
+  });
+
+  const el = document.getElementById("persona_text");
+  if (el && initialPersona) el.value = initialPersona;
+  el?.addEventListener("input", (e) => {
+    onChange?.(e.target.value);
+  });
+}

--- a/src/static/js/windows/search.js
+++ b/src/static/js/windows/search.js
@@ -1,0 +1,22 @@
+// applications/windows/search.js
+export function initSearchWindow({ sdk, spawnWindow }) {
+  if (typeof spawnWindow !== "function") throw new Error("spawnWindow missing");
+
+  spawnWindow({
+    id: "win_search",
+    title: "Semantic Search",
+    col: "right",
+    window_type: "window_generic",
+    Elements: [
+      { type: "text_field", id: "search_q", label: "Query", placeholder: "Search..." },
+      { type: "submit_button", id: "search_run", text: "Search" },
+      { type: "list_view", id: "search_results", items: [], template: { title: r => r.source, subtitle: r => String(r.score) } }
+    ]
+  });
+
+  document.getElementById("search_run")?.addEventListener("click", async () => {
+    const q = document.getElementById("search_q").value;
+    const res = await sdk.search.run({ q });
+    document.getElementById("search_results")?.update({ items: res.results || [] });
+  });
+}

--- a/src/static/js/windows/sessions.js
+++ b/src/static/js/windows/sessions.js
@@ -1,0 +1,21 @@
+// applications/windows/sessions.js
+export function initSessionsWindow({ sdk, spawnWindow }) {
+  if (typeof spawnWindow !== "function") throw new Error("spawnWindow missing");
+
+  spawnWindow({
+    id: "win_history",
+    title: "Chat Sessions",
+    col: "left",
+    window_type: "window_generic",
+    Elements: [
+      { type: "list_view", id: "session_list", items: [], template: { title: it => it.id } }
+    ]
+  });
+
+  async function refreshSessions() {
+    const items = await sdk.sessions.list();
+    document.getElementById("session_list")?.update({ items, template: { title: it => it.id } });
+  }
+
+  refreshSessions();
+}

--- a/src/static/js/windows/templates.js
+++ b/src/static/js/windows/templates.js
@@ -1,0 +1,36 @@
+// applications/windows/templates.js
+export function initTemplatesWindow({ sdk, spawnWindow }) {
+  if (typeof spawnWindow !== "function") throw new Error("spawnWindow missing");
+
+  spawnWindow({
+    id: "win_templates",
+    title: "Prompt Templates",
+    col: "right",
+    window_type: "window_generic",
+    Elements: [
+      { type: "list_view", id: "tpl_list", items: [], template: { title: t => t.id, subtitle: t => t.name } },
+      { type: "text_field", id: "tpl_id", label: "ID" },
+      { type: "text_field", id: "tpl_name", label: "Name" },
+      { type: "text_area", id: "tpl_user", label: "User Format" },
+      { type: "text_area", id: "tpl_system", label: "System Prompt" },
+      { type: "submit_button", id: "tpl_save", text: "Save" }
+    ]
+  });
+
+  async function refreshTemplates() {
+    const tpls = await sdk.templates.list();
+    document.getElementById("tpl_list")?.update({ items: tpls });
+  }
+  refreshTemplates();
+
+  document.getElementById("tpl_save")?.addEventListener("click", async () => {
+    const id = document.getElementById("tpl_id").value;
+    const name = document.getElementById("tpl_name").value;
+    const user_format = document.getElementById("tpl_user").value;
+    const system = document.getElementById("tpl_system").value;
+    if (id) {
+      await sdk.templates.put(id, { id, name, user_format, system });
+      refreshTemplates();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- move chat, sessions, search, persona editor, and template windows into dedicated files
- load new window modules from main.js

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a232711d34832c96511dfd7ae2119c