### PR TITLE
Display sessions and template dropdown

### DIFF
--- a/src/static/js/windows/sessions.js
+++ b/src/static/js/windows/sessions.js
@@ -8,13 +8,29 @@ export function initSessionsWindow({ sdk, spawnWindow }) {
     col: "left",
     window_type: "window_generic",
     Elements: [
-      { type: "list_view", id: "session_list", items: [], template: { title: it => it.id } }
+      {
+        type: "list_view",
+        id: "session_list",
+        keyField: "session_id",
+        items: [],
+        template: {
+          title: s => s.title || s.session_id,
+          subtitle: s => new Date(s.created_at).toLocaleString()
+        }
+      }
     ]
   });
 
   async function refreshSessions() {
     const items = await sdk.sessions.list();
-    document.getElementById("session_list")?.update({ items, template: { title: it => it.id } });
+    document.getElementById("session_list")?.update({
+      items,
+      keyField: "session_id",
+      template: {
+        title: s => s.title || s.session_id,
+        subtitle: s => new Date(s.created_at).toLocaleString()
+      }
+    });
   }
 
   refreshSessions();


### PR DESCRIPTION
## Summary
- Show chat session titles and timestamps in session list
- Switch prompt template manager to dropdown selection and auto-fill fields

## Testing
- `node --version`
- `node --check src/static/js/windows/sessions.js`
- `node --check src/static/js/windows/templates.js`
- `python -m py_compile testing.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2348f2758832cb32116e753a16a83