### PR TITLE
Track active LLM service in client and include in chat requests

### DIFF
--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -35,16 +35,18 @@ async function ensureSessionId(sdk) {
 // now ensure chat session
 const sessionId = await ensureSessionId(sdk);
 let persona = "";
+let llmSelection = null;
 
 // ---- APP INIT ----
 window.addEventListener("DOMContentLoaded", async () => {
   initFramework();
   // ensure user session cookie exists before anything else
   await sdk.auth.beginUser();
+  llmSelection = await sdk.llm.getSelection().catch(() => null);
 
   document.getElementById("menu-chat")?.addEventListener("click", (e) => {
     e.preventDefault();
-    initChatWindow({ sdk, sessionId, getPersona: () => persona, spawnWindow });
+    initChatWindow({ sdk, sessionId, getPersona: () => persona, getLLMSelection: () => llmSelection, spawnWindow });
   });
 
   document.getElementById("menu-chat-history")?.addEventListener("click", (e) => {
@@ -64,7 +66,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   document.getElementById("menu-llm")?.addEventListener("click", (e) => {
     e.preventDefault();
-    initLLMServicesWindows({ sdk, spawnWindow });
+    initLLMServicesWindows({ sdk, spawnWindow, onSelectionChange: (sel) => { llmSelection = sel; } });
   });
 
   document.getElementById("menu-templates")?.addEventListener("click", (e) => {

--- a/src/static/js/sdk.js
+++ b/src/static/js/sdk.js
@@ -68,6 +68,8 @@ export class DKClient {
         const body = this._form({
           message: p.message,
           session_id: p.sessionId,
+          service_id: p.serviceId,
+          model_id: p.modelId,
           persona: p.persona ?? "",
           template_id: p.templateId ?? "rag_chat",
           top_k: p.topK ?? 8,
@@ -81,6 +83,8 @@ export class DKClient {
         const body = this._form({
           message: p.message,
           session_id: p.sessionId,
+          service_id: p.serviceId,
+          model_id: p.modelId,
           persona: p.persona ?? "",
           template_id: p.templateId ?? "rag_chat",
           top_k: p.topK ?? 8,
@@ -94,6 +98,8 @@ export class DKClient {
         const body = this._form({
           message: p.message,
           session_id: p.sessionId,
+          service_id: p.serviceId,
+          model_id: p.modelId,
           persona: p.persona ?? "",
           template_id: p.templateId ?? "rag_chat",
           top_k: p.topK ?? 8,

--- a/src/static/js/windows/chat.js
+++ b/src/static/js/windows/chat.js
@@ -1,5 +1,5 @@
 // applications/windows/chat.js
-export function initChatWindow({ sdk, sessionId, getPersona, spawnWindow }) {
+export function initChatWindow({ sdk, sessionId, getPersona, getLLMSelection, spawnWindow }) {
   if (typeof spawnWindow !== "function") throw new Error("spawnWindow missing");
 
   spawnWindow({
@@ -8,10 +8,13 @@ export function initChatWindow({ sdk, sessionId, getPersona, spawnWindow }) {
     col: "right",
     window_type: "window_chat",
     onSend: async (text) => {
+      const sel = typeof getLLMSelection === "function" ? getLLMSelection() : null;
       const out = await sdk.chat.send({
         sessionId,
         message: text,
         persona: typeof getPersona === "function" ? getPersona() : "",
+        serviceId: sel?.service_id,
+        modelId: sel?.model_id,
       });
       return { role: "assistant", content: out.response };
     },

--- a/src/static/js/windows/llm_services.js
+++ b/src/static/js/windows/llm_services.js
@@ -16,7 +16,7 @@ const llmApi = (sdk) => ({
   setActive:    ({ service_id, model_id }) => sdk.llm.updateSelection({ service_id, model_id }),
 });
 
-export function initLLMServicesWindows({ sdk, spawnWindow }) {
+export function initLLMServicesWindows({ sdk, spawnWindow, onSelectionChange }) {
   if (typeof spawnWindow !== "function") throw new Error("spawnWindow missing");
 
   // ===== Window A: Services List =====
@@ -135,6 +135,7 @@ export function initLLMServicesWindows({ sdk, spawnWindow }) {
       api.getSelection().catch(() => null),
     ]);
     currentSelection = selection || null;
+    if (typeof onSelectionChange === "function") onSelectionChange(currentSelection);
 
     const rows = services.map((s) => ({
       ...s,


### PR DESCRIPTION
## Summary
- maintain currently selected LLM service on the client and update it when user changes selection
- pass active service and model IDs in chat requests
- expose selected service to chat window and LLM service manager

## Testing
- `node --check src/static/js/main.js`
- `node --check src/static/js/windows/chat.js`
- `node --check src/static/js/windows/llm_services.js`
- `node --check src/static/js/sdk.js`
- `python -m py_compile testing.py`


------
https://chatgpt.com/codex/tasks/task_e_68a23dc16338832c92cb09ecfa438e6a