### PR TITLE
feat: include user id in chat and llm selection

### DIFF
--- a/src/static/js/sdk.js
+++ b/src/static/js/sdk.js
@@ -68,6 +68,7 @@ export class DKClient {
         const body = this._form({
           message: p.message,
           session_id: p.sessionId,
+          user_id: p.userId,
           service_id: p.serviceId,
           model_id: p.modelId,
           persona: p.persona ?? "",
@@ -83,6 +84,7 @@ export class DKClient {
         const body = this._form({
           message: p.message,
           session_id: p.sessionId,
+          user_id: p.userId,
           service_id: p.serviceId,
           model_id: p.modelId,
           persona: p.persona ?? "",
@@ -98,6 +100,7 @@ export class DKClient {
         const body = this._form({
           message: p.message,
           session_id: p.sessionId,
+          user_id: p.userId,
           service_id: p.serviceId,
           model_id: p.modelId,
           persona: p.persona ?? "",

--- a/src/static/js/windows/chat.js
+++ b/src/static/js/windows/chat.js
@@ -2,6 +2,15 @@
 export function initChatWindow({ sdk, sessionId, getPersona, getLLMSelection, spawnWindow }) {
   if (typeof spawnWindow !== "function") throw new Error("spawnWindow missing");
 
+  async function getUserId() {
+    try {
+      const u = await sdk.sessions.getUser();
+      return u?.id ?? u?.user_id ?? u?.userId ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   spawnWindow({
     id: "win_chat",
     title: "Chat",
@@ -27,8 +36,11 @@ export function initChatWindow({ sdk, sessionId, getPersona, getLLMSelection, sp
       // (optional) sanity log
       // console.debug("chat selection:", sel);
 
+      const uid = await getUserId();
+
       const out = await sdk.chat.send({
         sessionId,
+        userId: uid,
         message: text,
         persona: (typeof getPersona === "function" ? getPersona() : ""),
         serviceId: sel?.service_id || "",   // non-empty ensures it’s included in form body

--- a/src/static/js/windows/llm_services.js
+++ b/src/static/js/windows/llm_services.js
@@ -6,6 +6,15 @@ let svcTable;
 let currentSelection = null; // { service_id, model_id }
 let editingId = null;
 
+async function getUserId(sdk) {
+  try {
+    const u = await sdk.sessions.getUser();
+    return u?.id ?? u?.user_id ?? u?.userId ?? null;
+  } catch {
+    return null;
+  }
+}
+
 // helpers for sdk.llm method names
 const llmApi = (sdk) => ({
   list:         () => sdk.llm.listServices(),
@@ -14,14 +23,9 @@ const llmApi = (sdk) => ({
   update:       (id,p)=> sdk.llm.updateService ? sdk.llm.updateService(id,p) : sdk.llm.putService(id,p),
   remove:       (id)  => sdk.llm.deleteService ? sdk.llm.deleteService(id) : sdk.llm.removeService(id),
   setActive: async ({ service_id, model_id }) => {
-  // server expects user_id in body; fetch it and include
-  let uid = null;
-  try {
-    const u = await sdk.sessions.getUser();
-    uid = u?.user_id || u?.id || u?.userId;
-  } catch {}
-  return sdk.llm.updateSelection({ user_id: uid, service_id, model_id });
-},
+    const uid = await getUserId(sdk);
+    return sdk.llm.updateSelection({ user_id: uid, service_id, model_id });
+  },
 });
 
 export function initLLMServicesWindows({ sdk, spawnWindow }) {


### PR DESCRIPTION
## Summary
- fetch user id from session API for chat and LLM service selection
- pass user id through SDK chat methods and selection updates

## Testing
- `node --check src/static/js/sdk.js src/static/js/windows/chat.js src/static/js/windows/llm_services.js`
- `python -m py_compile testing.py`


------
https://chatgpt.com/codex/tasks/task_e_68a24f86b934832c8a9b7a2f27d06855