### PR TITLE
feat: track LLM service selection client-side

### DIFF
--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -66,7 +66,12 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   document.getElementById("menu-llm")?.addEventListener("click", (e) => {
     e.preventDefault();
-    initLLMServicesWindows({ sdk, spawnWindow, onSelectionChange: (sel) => { llmSelection = sel; } });
+    initLLMServicesWindows({
+      sdk,
+      spawnWindow,
+      initialSelection: llmSelection,
+      onSelectionChange: (sel) => { llmSelection = sel; }
+    });
   });
 
   document.getElementById("menu-templates")?.addEventListener("click", (e) => {


### PR DESCRIPTION
## Summary
- keep LLM service selection in browser state instead of sending update requests
- expose selection to other windows through callbacks

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a25bcef084832c8cf31f7788a3a75a