### PR TITLE
Fix chat message rendering and LLM model display

### DIFF
--- a/src/static/js/windows/llm_services.js
+++ b/src/static/js/windows/llm_services.js
@@ -231,6 +231,7 @@ export function initLLMServicesWindows({ sdk, spawnWindow, initialSelection = nu
     const models = await sdk.llm.listModels(currentSelection.service_id).catch(() => []);
     modelRows = models.map((m) => ({
       ...m,
+      model: m.model || m.model_name || m.modelId || m.model_id || "",
       status: m.is_enabled ? "enabled" : "disabled",
       active: currentSelection?.model_id === m.id ? "✓" : "",
     }));
@@ -327,7 +328,7 @@ export function initLLMServicesWindows({ sdk, spawnWindow, initialSelection = nu
     setValue("model_id",      m?.id || "");
     setValue("model_service", currentSelection?.service_id || "");
     setValue("model_name",    m?.name || "");
-    setValue("model_model",   m?.model || "");
+    setValue("model_model",   m?.model || m?.model_name || m?.modelId || m?.model_id || "");
     setValue("model_mode",    m?.mode || "");
     setValue("model_extra",   prettyJSON(m?.extra) || "");
   }

--- a/submodules/deployable-ui/src/ui/js/windows/window_chat.js
+++ b/submodules/deployable-ui/src/ui/js/windows/window_chat.js
@@ -79,8 +79,16 @@ export function render(config = {}, winId) {
     const role = msg.role || "assistant";
     const node = el("div", { class: `chat-msg is-${role}` });
     const content = msg.content;
-    if (content instanceof HTMLElement) node.appendChild(content);
-    else node.append(String(content ?? ""));
+
+    if (content instanceof HTMLElement) {
+      node.appendChild(content);
+    } else if (typeof content === "string" && role === "assistant") {
+      // backend responses may include HTML (e.g., <p> tags). Render it.
+      node.innerHTML = content;
+    } else {
+      node.textContent = String(content ?? "");
+    }
+
     if (msg.meta) node.appendChild(el("div", { class: "chat-meta" }, [msg.meta]));
     log.appendChild(node);
     if (cfg.autoScroll !== false) log.scrollTop = log.scrollHeight;


### PR DESCRIPTION
## Summary
- Render assistant messages as HTML so backend formatting displays correctly
- Ensure newly added LLM models retain their model string when reloaded

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a27cc81820832cac5a4611e41cc521