### PR TITLE
Improve chat UI and LLM list interactions

### DIFF
--- a/src/static/js/windows/sessions.js
+++ b/src/static/js/windows/sessions.js
@@ -1,5 +1,5 @@
 // applications/windows/sessions.js
-export function initSessionsWindow({ sdk, spawnWindow }) {
+export function initSessionsWindow({ sdk, spawnWindow, onSelect, onNewChat }) {
   if (typeof spawnWindow !== "function") throw new Error("spawnWindow missing");
 
   spawnWindow({
@@ -8,11 +8,15 @@ export function initSessionsWindow({ sdk, spawnWindow }) {
     col: "left",
     window_type: "window_generic",
     Elements: [
+      { type: "submit_button", id: "session_new", text: "New Chat" },
       {
         type: "list_view",
         id: "session_list",
+        label: "Previous Chats",
+        labelPosition: "top",
         keyField: "session_id",
         items: [],
+        onRowClick: (s) => onSelect?.(s),
         template: {
           title: s => s.title || s.session_id,
           subtitle: s => new Date(s.created_at).toLocaleString()
@@ -21,11 +25,19 @@ export function initSessionsWindow({ sdk, spawnWindow }) {
     ]
   });
 
+  document.getElementById("session_new")?.addEventListener("click", async () => {
+    if (typeof onNewChat === "function") {
+      await onNewChat();
+      await refreshSessions();
+    }
+  });
+
   async function refreshSessions() {
     const items = await sdk.sessions.list();
     document.getElementById("session_list")?.update({
       items,
       keyField: "session_id",
+      onRowClick: (s) => onSelect?.(s),
       template: {
         title: s => s.title || s.session_id,
         subtitle: s => new Date(s.created_at).toLocaleString()

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -17,6 +17,7 @@
           <button class="dropbtn">Tools</button>
           <div class="dropdown-content">
             <a href="#" id="menu-chat">Chat</a>
+            <a href="#" id="menu-new-chat">New Chat</a>
             <a href="#" id="menu-chat-history">Chat History</a>
             <a href="#" id="menu-docs">Document Library</a>
             <a href="#" id="menu-segments">Document Segments</a>

--- a/submodules/deployable-ui/src/ui/css/components.list.css
+++ b/submodules/deployable-ui/src/ui/css/components.list.css
@@ -13,3 +13,6 @@
 .item-list button {
   margin-right: 4px;
 }
+.item-list tr.is-selectable {
+  cursor: pointer;
+}

--- a/submodules/deployable-ui/src/ui/css/framework.css
+++ b/submodules/deployable-ui/src/ui/css/framework.css
@@ -576,6 +576,9 @@ html, body {
 .item-list button {
   margin-right: 4px;
 }
+.item-list tr.is-selectable {
+  cursor: pointer;
+}
 .modal-overlay {
   position: fixed;
   inset: 0;

--- a/submodules/deployable-ui/src/ui/js/components/list.js
+++ b/submodules/deployable-ui/src/ui/js/components/list.js
@@ -17,7 +17,9 @@ export function createItemList({
     th.textContent = col.label || col.key;
     headerRow.appendChild(th);
   }
-  if (Object.keys(actions).length) {
+  const selectAction = actions.select;
+  const otherActions = Object.entries(actions).filter(([name]) => name !== "select");
+  if (otherActions.length) {
     const th = document.createElement("th");
     headerRow.appendChild(th);
   }
@@ -66,15 +68,22 @@ export function createItemList({
         td.textContent = item[col.key];
         tr.appendChild(td);
       }
-      if (Object.keys(actions).length) {
+      if (otherActions.length) {
         const td = document.createElement("td");
-        for (const [name, fn] of Object.entries(actions)) {
+        for (const [name, fn] of otherActions) {
           const btn = document.createElement("button");
           btn.textContent = name;
           btn.addEventListener("click", () => fn(item));
           td.appendChild(btn);
         }
         tr.appendChild(td);
+      }
+      if (selectAction) {
+        tr.classList.add("is-selectable");
+        tr.addEventListener("click", (ev) => {
+          if (ev.target.closest("button")) return;
+          selectAction(item);
+        });
       }
       tbody.appendChild(tr);
     }

--- a/submodules/deployable-ui/src/ui/js/windows/window_chat.js
+++ b/submodules/deployable-ui/src/ui/js/windows/window_chat.js
@@ -82,7 +82,7 @@ export function render(config = {}, winId) {
 
     if (content instanceof HTMLElement) {
       node.appendChild(content);
-    } else if (typeof content === "string" && role === "assistant") {
+    } else if (typeof content === "string") {
       // backend responses may include HTML (e.g., <p> tags). Render it.
       node.innerHTML = content;
     } else {


### PR DESCRIPTION
## Summary
- render chat responses as HTML
- allow LLM service and model lists to select rows with a click
- add new chat controls and chat history improvements

## Testing
- `python -m py_compile testing.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3433ecc18832c897ad6d2e0e78435