### PR TITLE
refactor: adopt framework windows and user-scoped chat

### DIFF
--- a/src/static/css/label-fixes.css
+++ b/src/static/css/label-fixes.css
@@ -1,0 +1,5 @@
+/* Temporary until framework fixes label_position */
+.label-top .field-label {
+  display: block;
+  margin-bottom: 6px;
+}

--- a/src/static/js/state.js
+++ b/src/static/js/state.js
@@ -1,0 +1,45 @@
+const KEY_SESSION = 'dk.session';
+const KEY_SEL = 'dk.selection';
+const KEY_INACTIVE = 'dk.inactive';
+
+const inactiveSet = new Set();
+try {
+  const raw = localStorage.getItem(KEY_INACTIVE);
+  if (raw) JSON.parse(raw).forEach((id) => inactiveSet.add(id));
+} catch {}
+
+function syncInactive() {
+  try { localStorage.setItem(KEY_INACTIVE, JSON.stringify([...inactiveSet])); } catch {}
+}
+
+export function setSessionId(id) {
+  if (id) localStorage.setItem(KEY_SESSION, id);
+  else localStorage.removeItem(KEY_SESSION);
+}
+export function getSessionId() {
+  return localStorage.getItem(KEY_SESSION);
+}
+
+export function setSelection(sel) {
+  try { localStorage.setItem(KEY_SEL, JSON.stringify(sel || {})); } catch {}
+}
+export function getSelection() {
+  try { return JSON.parse(localStorage.getItem(KEY_SEL) || '{}'); } catch { return {}; }
+}
+
+export function addInactiveIds(ids = []) {
+  ids.forEach((id) => inactiveSet.add(id));
+  syncInactive();
+}
+export function removeInactiveIds(ids = []) {
+  ids.forEach((id) => inactiveSet.delete(id));
+  syncInactive();
+}
+export function getInactiveIds() {
+  return [...inactiveSet];
+}
+
+export function getTopK() {
+  const el = document.getElementById('top-k-select');
+  return el ? Number(el.value) || null : null;
+}

--- a/src/static/js/windows/chat.js
+++ b/src/static/js/windows/chat.js
@@ -1,53 +1,21 @@
-// applications/windows/chat.js
-export function initChatWindow({ sdk, sessionId, getPersona, getLLMSelection, spawnWindow }) {
-  if (typeof spawnWindow !== "function") throw new Error("spawnWindow missing");
+import { spawnWindow } from '/static/ui/js/window.js';
+import { sendChat } from '../sdk.js';
+import { getInactiveIds, getTopK, getSelection } from '../state.js';
 
-  async function getUserId() {
-    try {
-      const u = await sdk.sessions.getUser();
-      return u?.id ?? u?.user_id ?? u?.userId ?? null;
-    } catch {
-      return null;
-    }
-  }
-
+export function createChatWindow() {
   spawnWindow({
-    id: "win_chat",
-    title: "Chat",
-    col: "right",
-    window_type: "window_chat",
+    id: 'win_chat',
+    title: 'Chat',
+    col: 'right',
+    window_type: 'window_chat',
     onSend: async (text) => {
-      // Use caller’s selection if present; otherwise fetch from API
-      const selLocal = (typeof getLLMSelection === "function") ? getLLMSelection() : null;
-      let sel = selLocal;
-
-      // normalize camel/snake just in case
-      if (sel && (sel.serviceId || sel.modelId)) {
-        sel = {
-          service_id: sel.service_id ?? sel.serviceId ?? null,
-          model_id:   sel.model_id   ?? sel.modelId   ?? null,
-        };
-      }
-
-      if (!sel?.service_id) {
-        try { sel = await sdk.llm.getSelection(); } catch { sel = null; }
-      }
-
-      // (optional) sanity log
-      // console.debug("chat selection:", sel);
-
-      const uid = await getUserId();
-
-      const out = await sdk.chat.send({
-        sessionId,
-        userId: uid,
-        message: text,
-        persona: (typeof getPersona === "function" ? getPersona() : ""),
-        serviceId: sel?.service_id || "",   // non-empty ensures it’s included in form body
-        modelId:   sel?.model_id   || "",
+      const resp = await sendChat({
+        prompt: text,
+        inactiveIds: getInactiveIds(),
+        topK: getTopK(),
+        selection: getSelection()
       });
-
-      return { role: "assistant", content: out.response };
-    },
+      return { role: 'assistant', content: resp.response };
+    }
   });
 }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,10 +3,12 @@
 <head>
   <meta charset="utf-8">
   <title>Deployable Knowledge Web</title>
-  <link rel="stylesheet" href="/static/ui/css/framework.css">
-  <link rel="stylesheet" href="/static/ui/css/style.css">
+  <link rel="stylesheet" href="/static/ui/css/theme.css">
+  <link rel="stylesheet" href="/static/ui/css/ui.css">
+  <link rel="stylesheet" href="/static/css/label-fixes.css">
   <link rel="stylesheet" href="/static/css/app.css">
-  <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+NfCgAAAAASUVORK5CYII=">
+  <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8A
+AwMCAO+NfCgAAAAASUVORK5CYII=">
 </head>
 <body>
   <header class="title-bar">
@@ -45,6 +47,7 @@
     <div id="splitter" class="splitter" role="separator" aria-orientation="vertical"></div>
     <section id="col-right" class="col"></section>
   </main>
+  <script type="module" src="/static/ui/js/framework.js"></script>
   <script type="module" src="/static/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include user_id in SDK helpers for LLM selection and chat
- swap custom window lists with framework item_list components and persist selection
- send chat requests with inactive IDs, topK, and current selection
- load framework assets first and add temporary `.label-top` fix

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3599a0990832ca66aa62cde28ac0b