### PR TITLE
Refactor UI scripts into modules and external stylesheet

### DIFF
--- a/static/app/js/chat.js
+++ b/static/app/js/chat.js
@@ -1,0 +1,67 @@
+export function setupChatUI({ getSDK, ensureSession, getSessionId, elements, helpers }) {
+  const { persona, templateId, chatTopK, inactive, msg, send, stream, meta, chatOut, userId, svcSel, modelSel } = elements;
+  const { ensureSDK, setBusy, toastERR, safeParse } = helpers;
+
+  send.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      const sdk = getSDK();
+      setBusy(send, true);
+      await ensureSession();
+      chatOut.textContent = '';
+      meta.textContent = '';
+      const res = await sdk.chat.send({
+        message: msg.value,
+        sessionId: getSessionId(),
+        userId: userId.value || 'local-user',
+        serviceId: svcSel.value || undefined,
+        modelId: modelSel.value || undefined,
+        persona: persona.value || '',
+        templateId: templateId.value || 'rag_chat',
+        topK: Number(chatTopK.value) || 8,
+        inactive: safeParse(inactive.value, undefined)
+      });
+      chatOut.innerHTML = res.response;
+    } catch (e) {
+      toastERR(chatOut, e);
+    } finally {
+      setBusy(send, false);
+    }
+  });
+
+  stream.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      const sdk = getSDK();
+      setBusy(stream, true);
+      await ensureSession();
+      chatOut.textContent = '';
+      meta.textContent = '';
+      const controller = new AbortController();
+      const p = {
+        message: msg.value,
+        sessionId: getSessionId(),
+        userId: userId.value || 'local-user',
+        serviceId: svcSel.value || undefined,
+        modelId: modelSel.value || undefined,
+        persona: persona.value || '',
+        templateId: templateId.value || 'rag_chat',
+        topK: Number(chatTopK.value) || 8,
+        inactive: safeParse(inactive.value, undefined),
+        signal: controller.signal,
+        onMeta: (m) => { meta.textContent = `meta: ${typeof m === 'string' ? m : JSON.stringify(m)}`; },
+        onToken: (t) => { chatOut.textContent += t; },
+        onDone: (final) => {
+          chatOut.textContent += '\n';
+          chatOut.textContent += '\n— DONE —\n' + JSON.stringify(final?.usage || {});
+        },
+        onError: (err) => { chatOut.textContent += `\n[error] ${err?.message || err}`; }
+      };
+      await sdk.chat.stream(p);
+    } catch (e) {
+      toastERR(chatOut, e);
+    } finally {
+      setBusy(stream, false);
+    }
+  });
+}

--- a/static/app/js/document_item.js
+++ b/static/app/js/document_item.js
@@ -1,0 +1,27 @@
+import { renderWithModes } from '/static/ui/js/render.js';
+
+export function createDocumentSchema({ onSegments } = {}) {
+  return {
+    modes: {
+      default: {
+        elements: {
+          source: { type: 'text', format: 'title' },
+          size:   { type: 'number' }
+        },
+        order: ['size'],
+        actions: [
+          {
+            id: 'segments',
+            label: 'Segments',
+            onAction: (values, ctx) => onSegments?.(values, ctx)
+          }
+        ]
+      }
+    }
+  };
+}
+
+export function renderDocumentItem(doc, deps = {}, opts = {}) {
+  const schema = createDocumentSchema(deps);
+  return renderWithModes(doc, schema, { mode: opts.mode || 'default' });
+}

--- a/static/app/js/documents.js
+++ b/static/app/js/documents.js
@@ -1,0 +1,47 @@
+import { renderDocumentItem } from './document_item.js';
+import { renderSegmentItem } from './segment_item.js';
+
+export function setupDocumentsUI({ getSDK, elements, helpers }) {
+  const { listDocs, docCount, docs, segSource, listSegs, segs, segView } = elements;
+  const { ensureSDK, setBusy, toastERR } = helpers;
+
+  listDocs.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      const sdk = getSDK();
+      setBusy(listDocs, true);
+      const res = await sdk.documents.list();
+      docCount.textContent = `${res?.length || 0} docs`;
+      docs.innerHTML = '';
+      (res || []).forEach(d => {
+        const host = renderDocumentItem(d, {
+          onSegments: () => { segSource.value = d.source || ''; }
+        });
+        docs.appendChild(host);
+      });
+    } catch (e) {
+      toastERR(docCount, e);
+    } finally {
+      setBusy(listDocs, false);
+    }
+  });
+
+  listSegs.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      const sdk = getSDK();
+      setBusy(listSegs, true);
+      const src = segSource.value.trim();
+      const res = await sdk.segments.list({ source: src || undefined });
+      segs.innerHTML = '';
+      (res || []).forEach(s => {
+        const host = renderSegmentItem(s, { sdk, segView });
+        segs.appendChild(host);
+      });
+    } catch (e) {
+      toastERR(segView, e);
+    } finally {
+      setBusy(listSegs, false);
+    }
+  });
+}

--- a/static/app/js/llm_service.js
+++ b/static/app/js/llm_service.js
@@ -1,0 +1,111 @@
+import { renderServiceCard } from './llm_services_item.js';
+import { renderModelCard } from './llm_service_model_item.js';
+
+export function setupLLMServiceUI({ getSDK, elements, helpers, userIdEl }) {
+  const { loadServices, refreshSel, svcSel, modelSel, setSelection, selOut, serviceCards, modelCards } = elements;
+  const { ensureSDK, setBusy, toastOK, toastERR } = helpers;
+
+  async function populateModels() {
+    try {
+      ensureSDK();
+      const sdk = getSDK();
+      const sid = svcSel.value;
+      modelSel.innerHTML = '';
+      if (!sid) return;
+      const models = await sdk.llm.listModels(sid);
+      for (const m of models) {
+        const opt = document.createElement('option');
+        opt.value = m.id;
+        opt.textContent = `${m.name || m.model_name || m.id} (${m.modality || m.mode || 'text'})`;
+        modelSel.appendChild(opt);
+      }
+    } catch (e) {
+      toastERR(selOut, e);
+    }
+  }
+
+  const cards = new Map();
+  const modelCardMap = new Map();
+
+  function highlight(ctx) {
+    for (const n of cards.values()) n.classList.remove('obj-card--selected');
+    ctx.node.classList.add('obj-card--selected');
+  }
+
+  async function renderModelsForService(serviceId) {
+    ensureSDK();
+    const sdk = getSDK();
+    modelCards.innerHTML = '';
+    modelCardMap.clear();
+    if (!serviceId) return;
+    const models = await sdk.llm.listModels(serviceId);
+    for (const m of models) {
+      const host = renderModelCard(m, {
+        sdk,
+        getUserId: () => userIdEl.value || 'local-user',
+        getSelectedServiceId: () => serviceId,
+        onSelect: (_values, ctx) => {
+          for (const n of modelCardMap.values()) n.classList.remove('obj-card--selected');
+          ctx.node.classList.add('obj-card--selected');
+          const opt = [...modelSel.options].find(o => o.value === m.id);
+          if (opt) modelSel.value = opt.value;
+        }
+      });
+      modelCards.appendChild(host);
+      modelCardMap.set(m.id, host);
+    }
+  }
+
+  loadServices.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      const sdk = getSDK();
+      const services = await sdk.llm.listServices();
+      serviceCards.innerHTML = '';
+      cards.clear();
+      for (const s of services) {
+        const host = renderServiceCard(s, {
+          sdk,
+          getUserId: () => userIdEl.value || 'local-user',
+          onSelect: async (_values, ctx) => {
+            highlight(ctx);
+            await renderModelsForService(s.id);
+          }
+        });
+        serviceCards.appendChild(host);
+        cards.set(s.id, host);
+      }
+    } catch (e) {
+      toastERR(selOut, e);
+    }
+  });
+
+  svcSel.addEventListener('change', populateModels);
+
+  setSelection.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      const sdk = getSDK();
+      const payload = {
+        user_id: userIdEl.value || 'local-user',
+        service_id: svcSel.value || undefined,
+        model_id: modelSel.value || undefined
+      };
+      const res = await sdk.llm.updateSelection(payload);
+      toastOK(selOut, res);
+    } catch (e) {
+      toastERR(selOut, e);
+    }
+  });
+
+  refreshSel.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      const sdk = getSDK();
+      const sel = await sdk.llm.getSelection();
+      toastOK(selOut, sel);
+    } catch (e) {
+      toastERR(selOut, e);
+    }
+  });
+}

--- a/static/app/js/main.js
+++ b/static/app/js/main.js
@@ -1,492 +1,270 @@
- import { renderWithModes, renderBySchema } from '/static/ui/js/render.js';
-    import { DKClient, ensureChatSessionId } from './sdk.js'; // adjust path if needed
-    import { llm_service_schema } from './schemas.js';
-    import { renderServiceCard } from "./llm_services_item.js";
-    import { renderModelCard } from './llm_service_model_item.js';
+import { DKClient } from './sdk.js';
+import { setupLLMServiceUI } from './llm_service.js';
+import { setupChatUI } from './chat.js';
+import { setupDocumentsUI } from './documents.js';
 
-    const $ = (id) => document.getElementById(id);
-    const j = (o) => JSON.stringify(o, null, 2);
-    const safeParse = (s, fallback) => { try { return JSON.parse(s); } catch { return fallback; } };
+const $ = (id) => document.getElementById(id);
+const j = (o) => JSON.stringify(o, null, 2);
+const safeParse = (s, fallback) => { try { return JSON.parse(s); } catch { return fallback; } };
 
-    // ---- elements ----
-    const base    = $('base');
-    const initBtn = $('init');
-    const prime   = $('prime');
-    const ensure  = $('ensure');
-    const sidOut  = $('sid');
+// ---- elements ----
+const base    = $('base');
+const initBtn = $('init');
+const prime   = $('prime');
+const ensure  = $('ensure');
+const sidOut  = $('sid');
 
-    const loadServices = $('loadServices');
-    const refreshSel   = $('refreshSelection');
-    const svcSel = $('svc');
-    const modelSel = $('model');
-    const setSelection = $('setSelection');
-    const selOut = $('selOut');
+const loadServices = $('loadServices');
+const refreshSel   = $('refreshSelection');
+const svcSel = $('svc');
+const modelSel = $('model');
+const setSelection = $('setSelection');
+const selOut = $('selOut');
+const serviceCards = $('serviceCards');
+const modelCards = $('modelCards');
 
-    const q = $('q');
-    const topK = $('topK');
-    const doSearch = $('doSearch');
-    const searchOut = $('searchOut');
+const q = $('q');
+const topK = $('topK');
+const doSearch = $('doSearch');
+const searchOut = $('searchOut');
 
-    const listDocs = $('listDocs');
-    const docCount = $('docCount');
-    const docs = $('docs');
+const listDocs = $('listDocs');
+const docCount = $('docCount');
+const docs = $('docs');
+const segSource = $('segSource');
+const listSegs = $('listSegs');
+const segs = $('segs');
+const segView = $('segView');
 
-    const segSource = $('segSource');
-    const listSegs = $('listSegs');
-    const segs = $('segs');
-    const segView = $('segView');
+const persona = $('persona');
+const templateId = $('templateId');
+const chatTopK = $('chatTopK');
+const inactive = $('inactive');
+const msg = $('msg');
+const send = $('send');
+const stream = $('stream');
+const meta = $('meta');
+const chatOut = $('chatOut');
 
-    const persona = $('persona');
-    const templateId = $('templateId');
-    const chatTopK = $('chatTopK');
-    const inactive = $('inactive');
-    const msg = $('msg');
-    const send = $('send');
-    const stream = $('stream');
-    const meta = $('meta');
-    const chatOut = $('chatOut');
+const files = $('files');
+const upload = $('upload');
+const ingestAll = $('ingestAll');
+const removeSource = $('removeSource');
+const removeBtn = $('remove');
+const clearDb = $('clearDb');
+const ingOut = $('ingOut');
 
-    const files = $('files');
-    const upload = $('upload');
-    const ingestAll = $('ingestAll');
-    const removeSource = $('removeSource');
-    const removeBtn = $('remove');
-    const clearDb = $('clearDb');
-    const ingOut = $('ingOut');
+const tplList = $('tplList');
+const tplId = $('tplId');
+const tplGet = $('tplGet');
+const userId = $('userId');
+const getSettings = $('getSettings');
+const miscOut = $('miscOut');
 
-    const tplList = $('tplList');
-    const tplId = $('tplId');
-    const tplGet = $('tplGet');
-    const userId = $('userId');
-    const getSettings = $('getSettings');
-    const miscOut = $('miscOut');
+// ---- state ----
+let sdk = null;
+let sessionId = null;
 
-    // ---- state ----
-    let sdk = null;
-    let sessionId = null;
+// default base -> same host, port 8000
+base.value = `${location.protocol}//${location.hostname}:8000`;
 
-    // default base -> same host, port 8000
-    base.value = `${location.protocol}//${location.hostname}:8000`;
-
-    function setBusy(el, busy) {
-      el.disabled = !!busy;
-      if (busy) el.dataset.oldText = el.textContent, el.textContent = '…';
-      else if (el.dataset.oldText) el.textContent = el.dataset.oldText;
-    }
-
-    function toastOK(outEl, data) {
-      outEl.textContent = (typeof data === 'string') ? data : j(data);
-      outEl.classList.remove('err'); outEl.classList.add('ok');
-    }
-    function toastERR(outEl, err) {
-      outEl.textContent = err?.message || String(err);
-      outEl.classList.remove('ok'); outEl.classList.add('err');
-    }
-
-    function ensureSDK() {
-      if (!sdk) throw new Error('Init SDK first.');
-    }
-
-    // ---- init & session ----
-    initBtn.addEventListener('click', () => {
-      try {
-        sdk = new DKClient({ baseUrl: base.value });
-        window.sdk = sdk; // for console play
-        selOut.textContent = 'SDK ready.';
-      } catch (e) {
-        toastERR(selOut, e);
-      }
-    });
-
-    prime.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        setBusy(prime, true);
-        await sdk.auth.beginUser();
-        toastOK(selOut, 'User session primed via /begin');
-      } catch (e) {
-        toastERR(selOut, e);
-      } finally {
-        setBusy(prime, false);
-      }
-    });
-
-    ensure.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        setBusy(ensure, true);
-        const res = await sdk.sessions.ensure();
-        sessionId = res.session_id;
-        sidOut.textContent = `session_id: ${sessionId}`;
-        toastOK(selOut, res);
-      } catch (e) {
-        toastERR(selOut, e);
-      } finally {
-        setBusy(ensure, false);
-      }
-    });
-
-    // ---- services/models ----
-    async function populateModels() {
-      try {
-        ensureSDK();
-        const sid = svcSel.value;
-        modelSel.innerHTML = '';
-        if (!sid) return;
-        const models = await sdk.llm.listModels(sid);
-        for (const m of models) {
-          const opt = document.createElement('option');
-          opt.value = m.id;
-          opt.textContent = `${m.name || m.model_name || m.id} (${m.modality || m.mode || 'text'})`;
-          modelSel.appendChild(opt);
-        }
-      } catch (e) {
-        toastERR(selOut, e);
-      }
-    }
-
-    const cards = new Map();
-    const highlight = (ctx, id) => {
-      for (const n of cards.values()) n.classList.remove("obj-card--selected");
-      ctx.node.classList.add("obj-card--selected");
-    };
-
-loadServices.onclick = async () => {
-  const services = await sdk.llm.listServices();
-  test.innerHTML = '';
-  cards.clear();
-
-  for (const s of services) {
-    const host = renderServiceCard(s, {
-      sdk,
-      getUserId: () => userId.value || 'local-user',
-      onSelect: async (_values, ctx) => {
-        highlight(ctx, s.id);           // your existing highlight
-        await renderModelsForService(s.id); // <- paint models for this service
-      }
-    });
-    test.appendChild(host);
-    cards.set(s.id, host);
-  }
-};
-
-
-
-    svcSel.addEventListener('change', populateModels);
-
-    setSelection.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        const payload = {
-          user_id: userId.value || 'local-user',
-          service_id: svcSel.value || undefined,
-          model_id: modelSel.value || undefined
-        };
-        const res = await sdk.llm.updateSelection(payload);
-        toastOK(selOut, res);
-      } catch (e) {
-        toastERR(selOut, e);
-      }
-    });
-
-    refreshSel.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        const sel = await sdk.llm.getSelection();
-        toastOK(selOut, sel);
-      } catch (e) {
-        toastERR(selOut, e);
-      }
-    });
-
-    // ---- search ----
-    doSearch.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        setBusy(doSearch, true);
-        const res = await sdk.search.run({
-          q: q.value,
-          topK: Number(topK.value) || 5,
-          inactive: safeParse(inactive.value, undefined)
-        });
-        toastOK(searchOut, res);
-      } catch (e) {
-        toastERR(searchOut, e);
-      } finally {
-        setBusy(doSearch, false);
-      }
-    });
-
-    // ---- documents & segments ----
-    listDocs.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        setBusy(listDocs, true);
-        const res = await sdk.documents.list();
-        docCount.textContent = `${res?.length || 0} docs`;
-        docs.innerHTML = '';
-        (res || []).forEach(d => {
-          const div = document.createElement('div');
-          div.className = 'item';
-          div.innerHTML = `<div><strong>${d.source || d.name || '(no source)'} </strong><div class="subtle">${d.size ? (d.size + ' bytes') : ''}</div></div>
-                           <div><button data-source="${d.source}">Segments</button></div>`;
-          div.querySelector('button').addEventListener('click', () => {
-            segSource.value = d.source || '';
-          });
-          docs.appendChild(div);
-        });
-      } catch (e) {
-        toastERR(searchOut, e);
-      } finally {
-        setBusy(listDocs, false);
-      }
-    });
-
-    listSegs.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        setBusy(listSegs, true);
-        const src = segSource.value.trim();
-        const res = await sdk.segments.list({ source: src || undefined });
-        segs.innerHTML = '';
-        (res || []).forEach(s => {
-          const row = document.createElement('div');
-          row.className = 'item';
-          const left = document.createElement('div');
-          left.innerHTML = `<div><strong>${s.source}</strong></div>
-                            <div class="subtle">#${s.segment_index ?? ''} — ${s.priority ?? ''}</div>
-                            <div class="subtle">${s.preview ?? ''}</div>`;
-          const right = document.createElement('div');
-          const bOpen = document.createElement('button');
-          bOpen.textContent = 'Open';
-          bOpen.addEventListener('click', async () => {
-            try {
-              const detail = await sdk.segments.get(s.id || s.uuid);
-              segView.textContent = detail?.text || '(no text)';
-            } catch (e) {
-              toastERR(segView, e);
-            }
-          });
-          const bDel = document.createElement('button');
-          bDel.textContent = 'Delete';
-          bDel.addEventListener('click', async () => {
-            try {
-              await sdk.segments.remove(s.id || s.uuid);
-              row.remove();
-            } catch (e) {
-              toastERR(segView, e);
-            }
-          });
-          right.appendChild(bOpen);
-          right.appendChild(bDel);
-          row.appendChild(left);
-          row.appendChild(right);
-          segs.appendChild(row);
-        });
-      } catch (e) {
-        toastERR(segView, e);
-      } finally {
-        setBusy(listSegs, false);
-      }
-    });
-
-    // ---- chat ----
-    async function ensureSession() {
-      if (!sessionId) {
-        const res = await sdk.sessions.ensure();
-        sessionId = res.session_id;
-        sidOut.textContent = `session_id: ${sessionId}`;
-      }
-      return sessionId;
-    }
-
-    send.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        setBusy(send, true);
-        await ensureSession();
-        chatOut.textContent = '';
-        meta.textContent = '';
-
-        const res = await sdk.chat.send({
-          message: msg.value,
-          sessionId,
-          userId: userId.value || 'local-user',
-          serviceId: svcSel.value || undefined,
-          modelId: modelSel.value || undefined,
-          persona: persona.value || '',
-          templateId: templateId.value || 'rag_chat',
-          topK: Number(chatTopK.value) || 8,
-          inactive: safeParse(inactive.value, undefined)
-        });
-        chatOut.innerHTML = res.response;
-      } catch (e) {
-        toastERR(chatOut, e);
-      } finally {
-        setBusy(send, false);
-      }
-    });
-
-    stream.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        setBusy(stream, true);
-        await ensureSession();
-        chatOut.textContent = '';
-        meta.textContent = '';
-
-        const controller = new AbortController();
-        const p = {
-          message: msg.value,
-          sessionId,
-          userId: userId.value || 'local-user',
-          serviceId: svcSel.value || undefined,
-          modelId: modelSel.value || undefined,
-          persona: persona.value || '',
-          templateId: templateId.value || 'rag_chat',
-          topK: Number(chatTopK.value) || 8,
-          inactive: safeParse(inactive.value, undefined),
-          signal: controller.signal,
-          onMeta: (m) => { meta.textContent = `meta: ${typeof m === 'string' ? m : JSON.stringify(m)}`; },
-          onToken: (t) => { chatOut.textContent += t; },
-          onDone: (final) => {
-            chatOut.textContent += '\n';
-            chatOut.textContent += '\n— DONE —\n' + j(final?.usage || {});
-          },
-          onError: (err) => { chatOut.textContent += `\n[error] ${err?.message || err}`; }
-        };
-        // choose one:
-        await sdk.chat.stream(p);      // /chat?stream=true
-        // await sdk.chat.streamAlways(p); // /chat-stream
-      } catch (e) {
-        toastERR(chatOut, e);
-      } finally {
-        setBusy(stream, false);
-      }
-    });
-
-    // ---- ingest ----
-    upload.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        setBusy(upload, true);
-        const res = await sdk.ingest.upload(files.files);
-        toastOK(ingOut, res);
-      } catch (e) {
-        toastERR(ingOut, e);
-      } finally {
-        setBusy(upload, false);
-      }
-    });
-
-    ingestAll.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        setBusy(ingestAll, true);
-        const res = await sdk.ingest.ingestAll();
-        toastOK(ingOut, res);
-      } catch (e) {
-        toastERR(ingOut, e);
-      } finally {
-        setBusy(ingestAll, false);
-      }
-    });
-
-    removeBtn.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        setBusy(removeBtn, true);
-        const res = await sdk.ingest.remove(removeSource.value.trim());
-        toastOK(ingOut, res);
-      } catch (e) {
-        toastERR(ingOut, e);
-      } finally {
-        setBusy(removeBtn, false);
-      }
-    });
-
-    clearDb.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        setBusy(clearDb, true);
-        const res = await sdk.ingest.clearDb();
-        toastOK(ingOut, res);
-      } catch (e) {
-        toastERR(ingOut, e);
-      } finally {
-        setBusy(clearDb, false);
-      }
-    });
-
-    // ---- templates & settings ----
-    tplList.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        const res = await sdk.templates.list();
-        toastOK(miscOut, res);
-      } catch (e) {
-        toastERR(miscOut, e);
-      }
-    });
-
-    tplGet.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        const res = await sdk.templates.get(tplId.value.trim());
-        toastOK(miscOut, res);
-      } catch (e) {
-        toastERR(miscOut, e);
-      }
-    });
-
-    getSettings.addEventListener('click', async () => {
-      try {
-        ensureSDK();
-        const res = await sdk.settings.get(userId.value || 'local-user');
-        toastOK(miscOut, res);
-      } catch (e) {
-        toastERR(miscOut, e);
-      }
-    });
-
-    // Optional: quick-start for sane defaults
-    (async function boot() {
-      try {
-        sdk = new DKClient({ baseUrl: base.value });
-        await sdk.auth.beginUser();
-        const res = await sdk.sessions.ensure();
-        sessionId = res.session_id;
-        sidOut.textContent = `session_id: ${sessionId}`;
-      } catch (e) {
-        // non-fatal on boot
-      }
-    })();
-
-const modelsWrap = document.getElementById('models');
-const modelCards = new Map(); // id -> host node
-
-async function renderModelsForService(serviceId) {
-  ensureSDK();
-  modelsWrap.innerHTML = '';
-  modelCards.clear();
-  if (!serviceId) return;
-
-  const models = await sdk.llm.listModels(serviceId);
-  for (const m of models) {
-    const host = renderModelCard(m, {
-      sdk,
-      getUserId: () => userId.value || 'local-user',
-      getSelectedServiceId: () => serviceId,
-      onSelect: (_values, ctx) => {
-        // highlight the chosen model card
-        for (const n of modelCards.values()) n.classList.remove('obj-card--selected');
-        ctx.node.classList.add('obj-card--selected');
-        // keep dropdown in sync if you’re still using it
-        const opt = [...modelSel.options].find(o => o.value === m.id);
-        if (opt) modelSel.value = opt.value;
-      }
-    });
-    modelsWrap.appendChild(host);
-    modelCards.set(m.id, host);
-  }
+function setBusy(el, busy) {
+  el.disabled = !!busy;
+  if (busy) el.dataset.oldText = el.textContent, el.textContent = '…';
+  else if (el.dataset.oldText) el.textContent = el.dataset.oldText;
 }
+
+function toastOK(outEl, data) {
+  outEl.textContent = (typeof data === 'string') ? data : j(data);
+  outEl.classList.remove('err'); outEl.classList.add('ok');
+}
+function toastERR(outEl, err) {
+  outEl.textContent = err?.message || String(err);
+  outEl.classList.remove('ok'); outEl.classList.add('err');
+}
+
+function ensureSDK() {
+  if (!sdk) throw new Error('Init SDK first.');
+}
+
+async function ensureSession() {
+  ensureSDK();
+  const res = await sdk.sessions.ensure();
+  sessionId = res.session_id;
+  sidOut.textContent = `session_id: ${sessionId}`;
+  return sessionId;
+}
+
+// ---- init & session ----
+initBtn.addEventListener('click', () => {
+  try {
+    sdk = new DKClient({ baseUrl: base.value });
+    window.sdk = sdk;
+    selOut.textContent = 'SDK ready.';
+  } catch (e) {
+    toastERR(selOut, e);
+  }
+});
+
+prime.addEventListener('click', async () => {
+  try {
+    ensureSDK();
+    setBusy(prime, true);
+    await sdk.auth.beginUser();
+    toastOK(selOut, 'User session primed via /begin');
+  } catch (e) {
+    toastERR(selOut, e);
+  } finally {
+    setBusy(prime, false);
+  }
+});
+ensure.addEventListener('click', async () => {
+  try {
+    setBusy(ensure, true);
+    await ensureSession();
+    toastOK(selOut, { session_id: sessionId });
+  } catch (e) {
+    toastERR(selOut, e);
+  } finally {
+    setBusy(ensure, false);
+  }
+});
+
+// ---- search ----
+doSearch.addEventListener('click', async () => {
+  try {
+    ensureSDK();
+    setBusy(doSearch, true);
+    const res = await sdk.search.run({
+      q: q.value,
+      topK: Number(topK.value) || 5,
+      inactive: safeParse(inactive.value, undefined)
+    });
+    toastOK(searchOut, res);
+  } catch (e) {
+    toastERR(searchOut, e);
+  } finally {
+    setBusy(doSearch, false);
+  }
+});
+
+// ---- documents & segments ----
+setupDocumentsUI({
+  getSDK: () => sdk,
+  elements: { listDocs, docCount, docs, segSource, listSegs, segs, segView },
+  helpers: { ensureSDK, setBusy, toastERR }
+});
+
+// ---- chat ----
+setupChatUI({
+  getSDK: () => sdk,
+  ensureSession,
+  getSessionId: () => sessionId,
+  elements: { persona, templateId, chatTopK, inactive, msg, send, stream, meta, chatOut, userId, svcSel, modelSel },
+  helpers: { ensureSDK, setBusy, toastERR, safeParse }
+});
+
+// ---- services/models ----
+setupLLMServiceUI({
+  getSDK: () => sdk,
+  userIdEl: userId,
+  elements: { loadServices, refreshSel, svcSel, modelSel, setSelection, selOut, serviceCards, modelCards },
+  helpers: { ensureSDK, setBusy, toastOK, toastERR }
+});
+
+// ---- ingest ----
+upload.addEventListener('click', async () => {
+  try {
+    ensureSDK();
+    setBusy(upload, true);
+    const res = await sdk.ingest.upload(files.files);
+    toastOK(ingOut, res);
+  } catch (e) {
+    toastERR(ingOut, e);
+  } finally {
+    setBusy(upload, false);
+  }
+});
+
+ingestAll.addEventListener('click', async () => {
+  try {
+    ensureSDK();
+    setBusy(ingestAll, true);
+    const res = await sdk.ingest.ingestAll();
+    toastOK(ingOut, res);
+  } catch (e) {
+    toastERR(ingOut, e);
+  } finally {
+    setBusy(ingestAll, false);
+  }
+});
+
+removeBtn.addEventListener('click', async () => {
+  try {
+    ensureSDK();
+    setBusy(removeBtn, true);
+    const res = await sdk.ingest.remove(removeSource.value.trim());
+    toastOK(ingOut, res);
+  } catch (e) {
+    toastERR(ingOut, e);
+  } finally {
+    setBusy(removeBtn, false);
+  }
+});
+
+clearDb.addEventListener('click', async () => {
+  try {
+    ensureSDK();
+    setBusy(clearDb, true);
+    const res = await sdk.ingest.clearDb();
+    toastOK(ingOut, res);
+  } catch (e) {
+    toastERR(ingOut, e);
+  } finally {
+    setBusy(clearDb, false);
+  }
+});
+
+// ---- templates & settings ----
+tplList.addEventListener('click', async () => {
+  try {
+    ensureSDK();
+    const res = await sdk.templates.list();
+    toastOK(miscOut, res);
+  } catch (e) {
+    toastERR(miscOut, e);
+  }
+});
+
+tplGet.addEventListener('click', async () => {
+  try {
+    ensureSDK();
+    const res = await sdk.templates.get(tplId.value.trim());
+    toastOK(miscOut, res);
+  } catch (e) {
+    toastERR(miscOut, e);
+  }
+});
+
+getSettings.addEventListener('click', async () => {
+  try {
+    ensureSDK();
+    const res = await sdk.settings.get(userId.value || 'local-user');
+    toastOK(miscOut, res);
+  } catch (e) {
+    toastERR(miscOut, e);
+  }
+});
+
+// Optional boot
+(async function boot() {
+  try {
+    sdk = new DKClient({ baseUrl: base.value });
+    await sdk.auth.beginUser();
+    const res = await sdk.sessions.ensure();
+    sessionId = res.session_id;
+    sidOut.textContent = `session_id: ${sessionId}`;
+  } catch (e) {
+    // non-fatal
+  }
+})();

--- a/static/app/js/segment_item.js
+++ b/static/app/js/segment_item.js
@@ -1,0 +1,41 @@
+import { renderWithModes } from '/static/ui/js/render.js';
+
+export function createSegmentSchema({ sdk, segView } = {}) {
+  return {
+    modes: {
+      default: {
+        elements: {
+          source:        { type: 'text' },
+          segment_index: { type: 'number' },
+          priority:      { type: 'number' },
+          preview:       { type: 'text' }
+        },
+        order: ['segment_index', 'priority', 'preview'],
+        actions: [
+          {
+            id: 'open',
+            label: 'Open',
+            onAction: async (values) => {
+              const detail = await sdk?.segments?.get(values.id || values.uuid);
+              segView.textContent = detail?.text || '(no text)';
+            }
+          },
+          {
+            id: 'delete',
+            label: 'Delete',
+            variant: 'danger',
+            onAction: async (values, ctx) => {
+              await sdk?.segments?.remove(values.id || values.uuid);
+              ctx.node.remove();
+            }
+          }
+        ]
+      }
+    }
+  };
+}
+
+export function renderSegmentItem(seg, deps = {}, opts = {}) {
+  const schema = createSegmentSchema(deps);
+  return renderWithModes(seg, schema, { mode: opts.mode || 'default' });
+}

--- a/static/ui/css/style.css
+++ b/static/ui/css/style.css
@@ -1,0 +1,58 @@
+:root { color-scheme: dark; }
+body { margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto; background:#0c0f13; color:#eaeef3; }
+header { padding:14px 18px; border-bottom:1px solid #1b232e; display:flex; gap:12px; align-items:center; }
+header input, header button, header select { background:#121821; color:#eaeef3; border:1px solid #2a3546; border-radius:6px; padding:8px 10px; }
+header button { cursor:pointer; }
+main { display:grid; grid-template-columns: 320px 1fr; gap:16px; padding:16px; }
+section { background:#0f141c; border:1px solid #1b232e; border-radius:10px; padding:12px; display:flex; flex-direction:column; gap:10px; }
+h2 { font-size:14px; font-weight:700; margin:0 0 4px 0; color:#b9c8dc; text-transform:uppercase; letter-spacing:0.06em; }
+.row { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
+label { font-size:12px; color:#99a9bf; }
+input, select, textarea { background:#0c1118; color:#eaeef3; border:1px solid #243042; border-radius:6px; padding:8px 10px; width:100%; }
+textarea { min-height:84px; resize:vertical; }
+button { background:#1d2736; color:#eaeef3; border:1px solid #2a3546; border-radius:8px; padding:8px 12px; cursor:pointer; }
+button:disabled { opacity:0.5; cursor:not-allowed; }
+pre, code { background:#0b0f15; border:1px solid #1c2736; border-radius:8px; padding:8px; overflow:auto; }
+.grid-2 { display:grid; grid-template-columns: 1fr 1fr; gap:12px; }
+.pill { padding:2px 8px; border:1px solid #2a3546; border-radius:999px; font-size:11px; color:#b9c8dc; }
+.spacer { height:8px; }
+.list { max-height:220px; overflow:auto; border:1px solid #1c2736; border-radius:8px; }
+.item { padding:8px 10px; border-bottom:1px solid #121821; display:flex; justify-content:space-between; gap:8px; }
+.item:last-child { border-bottom:0; }
+.subtle { color:#9ab; font-size:12px; }
+.mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.ok { color:#69f0ae; }
+.err { color:#ff867c; }
+footer { padding:12px 16px; border-top:1px solid #1b232e; font-size:12px; color:#8aa0b7; }
+/* toss into your page */
+.obj-card{border:1px solid #1b232e;border-radius:10px;background:#0f141c}
+.obj-card__head{padding:10px 12px;border-bottom:1px solid #1b232e}
+.obj-card__title{margin:0;font-size:16px;color:#cfe3ff}
+.obj-card__body{padding:10px 12px;display:flex;flex-direction:column;gap:8px}
+.obj-card__row{display:grid;grid-template-columns:180px 1fr;gap:8px;align-items:start}
+.obj-card__label{color:#9cb2c9;font-size:12px}
+.obj-card__value{color:#eaeef3;font-size:14px}
+.mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.pill{padding:2px 8px;border:1px solid #2a3546;border-radius:999px;font-size:11px}
+.pill--yes{border-color:#115e3b;background:#0d1f19;color:#69f0ae}
+.pill--no{border-color:#5e1111;background:#1f0d0d;color:#ff867c}
+.block{display:block}
+.inline{display:inline}
+.in{background:#0c1118;color:#eaeef3;border:1px solid #243042;border-radius:6px;padding:6px 8px}
+.in-text,.in-number{width:100%}
+.in-textarea{width:100%;min-height:96px;resize:vertical}
+.in-select{width:100%}
+.in-range{width:100%}
+.range-wrap{display:flex;gap:10px;align-items:center}
+.range-readout{min-width:44px;text-align:right}
+.combo-wrap{display:block}
+.obj-card__actions { display:flex; gap:8px; flex-wrap:wrap; margin-top:8px; }
+.obj-card__foot { padding:10px 12px; border-top:1px solid #1b232e; }
+.obj-card--selected { border-color:#3557ff; box-shadow: 0 0 0 1px #3557ff inset; }
+
+.btn { padding:6px 10px; border:1px solid #2a3546; border-radius:8px; background:#1d2736; color:#eaeef3; cursor:pointer; }
+.btn--primary { border-color:#3557ff; }
+.btn--danger  { border-color:#b33; }
+.btn--ghost   { background:transparent; }
+.obj-card--selected { border-color:#3557ff; box-shadow:0 0 0 1px #3557ff inset; }
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,67 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" href="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==">
 
-  <style>
-    :root { color-scheme: dark; }
-    body { margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto; background:#0c0f13; color:#eaeef3; }
-    header { padding:14px 18px; border-bottom:1px solid #1b232e; display:flex; gap:12px; align-items:center; }
-    header input, header button, header select { background:#121821; color:#eaeef3; border:1px solid #2a3546; border-radius:6px; padding:8px 10px; }
-    header button { cursor:pointer; }
-    main { display:grid; grid-template-columns: 320px 1fr; gap:16px; padding:16px; }
-    section { background:#0f141c; border:1px solid #1b232e; border-radius:10px; padding:12px; display:flex; flex-direction:column; gap:10px; }
-    h2 { font-size:14px; font-weight:700; margin:0 0 4px 0; color:#b9c8dc; text-transform:uppercase; letter-spacing:0.06em; }
-    .row { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
-    label { font-size:12px; color:#99a9bf; }
-    input, select, textarea { background:#0c1118; color:#eaeef3; border:1px solid #243042; border-radius:6px; padding:8px 10px; width:100%; }
-    textarea { min-height:84px; resize:vertical; }
-    button { background:#1d2736; color:#eaeef3; border:1px solid #2a3546; border-radius:8px; padding:8px 12px; cursor:pointer; }
-    button:disabled { opacity:0.5; cursor:not-allowed; }
-    pre, code { background:#0b0f15; border:1px solid #1c2736; border-radius:8px; padding:8px; overflow:auto; }
-    .grid-2 { display:grid; grid-template-columns: 1fr 1fr; gap:12px; }
-    .pill { padding:2px 8px; border:1px solid #2a3546; border-radius:999px; font-size:11px; color:#b9c8dc; }
-    .spacer { height:8px; }
-    .list { max-height:220px; overflow:auto; border:1px solid #1c2736; border-radius:8px; }
-    .item { padding:8px 10px; border-bottom:1px solid #121821; display:flex; justify-content:space-between; gap:8px; }
-    .item:last-child { border-bottom:0; }
-    .subtle { color:#9ab; font-size:12px; }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-    .ok { color:#69f0ae; }
-    .err { color:#ff867c; }
-    footer { padding:12px 16px; border-top:1px solid #1b232e; font-size:12px; color:#8aa0b7; }
-    /* toss into your page */
-.obj-card{border:1px solid #1b232e;border-radius:10px;background:#0f141c}
-.obj-card__head{padding:10px 12px;border-bottom:1px solid #1b232e}
-.obj-card__title{margin:0;font-size:16px;color:#cfe3ff}
-.obj-card__body{padding:10px 12px;display:flex;flex-direction:column;gap:8px}
-.obj-card__row{display:grid;grid-template-columns:180px 1fr;gap:8px;align-items:start}
-.obj-card__label{color:#9cb2c9;font-size:12px}
-.obj-card__value{color:#eaeef3;font-size:14px}
-.mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
-.pill{padding:2px 8px;border:1px solid #2a3546;border-radius:999px;font-size:11px}
-.pill--yes{border-color:#115e3b;background:#0d1f19;color:#69f0ae}
-.pill--no{border-color:#5e1111;background:#1f0d0d;color:#ff867c}
-.block{display:block}
-.inline{display:inline}
-.in{background:#0c1118;color:#eaeef3;border:1px solid #243042;border-radius:6px;padding:6px 8px}
-.in-text,.in-number{width:100%}
-.in-textarea{width:100%;min-height:96px;resize:vertical}
-.in-select{width:100%}
-.in-range{width:100%}
-.range-wrap{display:flex;gap:10px;align-items:center}
-.range-readout{min-width:44px;text-align:right}
-.combo-wrap{display:block}
-.obj-card__actions { display:flex; gap:8px; flex-wrap:wrap; margin-top:8px; }
-.obj-card__foot { padding:10px 12px; border-top:1px solid #1b232e; }
-.obj-card--selected { border-color:#3557ff; box-shadow: 0 0 0 1px #3557ff inset; }
-
-.btn { padding:6px 10px; border:1px solid #2a3546; border-radius:8px; background:#1d2736; color:#eaeef3; cursor:pointer; }
-.btn--primary { border-color:#3557ff; }
-.btn--danger  { border-color:#b33; }
-.btn--ghost   { background:transparent; }
-.obj-card--selected { border-color:#3557ff; box-shadow:0 0 0 1px #3557ff inset; }
-
-
-  </style>
+  <link rel="stylesheet" href="/static/ui/css/style.css" />
 </head>
 <body>
   <header>
@@ -192,8 +132,8 @@
         <pre id="miscOut" class="mono" style="max-height:200px;"></pre>
       </section>
     </div>
-<div id="test"></div>
-<div id="models"></div>
+<div id="serviceCards"></div>
+<div id="modelCards"></div>
 
 </main>
 


### PR DESCRIPTION
## Summary
- Move inline styles to `/static/ui/css/style.css` and link from template
- Extract chat, LLM service, and document/segment logic into dedicated modules
- Simplify `main.js` to wire up modular UI components

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_68a4bc6a82f0832c84f1ece2e1379395