### PR TITLE
Normalize document list items

### DIFF
--- a/static/app/js/document_item.js
+++ b/static/app/js/document_item.js
@@ -22,6 +22,7 @@ export function createDocumentSchema({ onSegments } = {}) {
 }
 
 export function renderDocumentItem(doc, deps = {}, opts = {}) {
+  const data = (typeof doc === 'string') ? { source: doc } : doc;
   const schema = createDocumentSchema(deps);
-  return renderWithModes(doc, schema, { mode: opts.mode || 'default' });
+  return renderWithModes(data, schema, { mode: opts.mode || 'default' });
 }

--- a/static/app/js/documents.js
+++ b/static/app/js/documents.js
@@ -14,8 +14,9 @@ export function setupDocumentsUI({ getSDK, elements, helpers }) {
       docCount.textContent = `${res?.length || 0} docs`;
       docs.innerHTML = '';
       (res || []).forEach(d => {
-        const host = renderDocumentItem(d, {
-          onSegments: () => { segSource.value = d.source || ''; }
+        const doc = (typeof d === 'string') ? { source: d } : d;
+        const host = renderDocumentItem(doc, {
+          onSegments: () => { segSource.value = doc.source || ''; }
         });
         docs.appendChild(host);
       });


### PR DESCRIPTION
## Summary
- Normalize document list entries before rendering.
- Allow `renderDocumentItem` to wrap string inputs as `{ source }`.

## Testing
- `node test.mjs` *(title: foo/path.txt)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e0c83284832cb120d2c1147f2c69