### PR TITLE
Populate LLM service/model selects and add prompt template UI

### DIFF
--- a/static/app/js/document_item.js
+++ b/static/app/js/document_item.js
@@ -5,15 +5,17 @@ export function createDocumentSchema({ onSegments } = {}) {
     modes: {
       mini: {
         elements: {
-          source: { type: 'text', format: 'title' }
-        }
+          title:  { type: 'text', format: 'title' },
+          source: { type: 'text' }
+        },
+        order: ['title','source']
       },
       default: {
         extends: 'mini',
         elements: {
           size: { type: 'number' }
         },
-        order: ['size'],
+        order: ['title','source','size'],
         actions: [
           {
             id: 'segments',

--- a/static/app/js/llm_service_admin.js
+++ b/static/app/js/llm_service_admin.js
@@ -1,0 +1,84 @@
+export function setupLLMServiceAdminUI({ getSDK, elements, helpers }) {
+  const {
+    createSvc,
+    deleteSvc,
+    createModel,
+    deleteModel,
+    newSvcProvider,
+    newSvcBaseUrl,
+    newSvcAuth,
+    delSvcId,
+    modelSvcId,
+    modelName,
+    modelModality,
+    delModelId,
+    out
+  } = elements;
+  const { ensureSDK, setBusy, toastOK, toastERR } = helpers;
+
+  createSvc.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      setBusy(createSvc, true);
+      const sdk = getSDK();
+      const payload = {
+        provider: newSvcProvider.value,
+        base_url: newSvcBaseUrl.value,
+        auth_ref: newSvcAuth.value || undefined
+      };
+      const res = await sdk.llm.createService(payload);
+      toastOK(out, res);
+    } catch (e) {
+      toastERR(out, e);
+    } finally {
+      setBusy(createSvc, false);
+    }
+  });
+
+  deleteSvc.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      setBusy(deleteSvc, true);
+      const sdk = getSDK();
+      const res = await sdk.llm.deleteService(delSvcId.value);
+      toastOK(out, res);
+    } catch (e) {
+      toastERR(out, e);
+    } finally {
+      setBusy(deleteSvc, false);
+    }
+  });
+
+  createModel.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      setBusy(createModel, true);
+      const sdk = getSDK();
+      const payload = {
+        service_id: modelSvcId.value,
+        model_name: modelName.value,
+        modality: modelModality.value
+      };
+      const res = await sdk.llm.createModel(payload);
+      toastOK(out, res);
+    } catch (e) {
+      toastERR(out, e);
+    } finally {
+      setBusy(createModel, false);
+    }
+  });
+
+  deleteModel.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      setBusy(deleteModel, true);
+      const sdk = getSDK();
+      const res = await sdk.llm.deleteModel(delModelId.value);
+      toastOK(out, res);
+    } catch (e) {
+      toastERR(out, e);
+    } finally {
+      setBusy(deleteModel, false);
+    }
+  });
+}

--- a/static/app/js/main.js
+++ b/static/app/js/main.js
@@ -2,6 +2,7 @@ import { DKClient } from './sdk.js';
 import { setupLLMServiceUI } from './llm_service.js';
 import { setupChatUI } from './chat.js';
 import { setupDocumentsUI } from './documents.js';
+import { setupPromptTemplatesUI } from './prompt_templates.js';
 import { initWindows } from '../../ui/js/windows.js';
 
 const $ = (id) => document.getElementById(id);
@@ -54,9 +55,9 @@ const removeBtn = $('remove');
 const clearDb = $('clearDb');
 const ingOut = $('ingOut');
 
-const tplList = $('tplList');
-const tplId = $('tplId');
-const tplGet = $('tplGet');
+const loadTemplates = $('loadTemplates');
+const tplSel = $('tplSel');
+const tplCard = $('tplCard');
 const userId = $('userId');
 const getSettings = $('getSettings');
 const miscOut = $('miscOut');
@@ -174,6 +175,13 @@ setupLLMServiceUI({
   helpers: { ensureSDK, setBusy }
 });
 
+// ---- prompt templates ----
+setupPromptTemplatesUI({
+  getSDK: () => sdk,
+  elements: { loadTemplates, tplSel, tplCard, templateId },
+  helpers: { ensureSDK }
+});
+
 // ---- ingest ----
 upload.addEventListener('click', async () => {
   try {
@@ -228,26 +236,6 @@ clearDb.addEventListener('click', async () => {
 });
 
 // ---- templates & settings ----
-tplList.addEventListener('click', async () => {
-  try {
-    ensureSDK();
-    const res = await sdk.templates.list();
-    toastOK(miscOut, res);
-  } catch (e) {
-    toastERR(miscOut, e);
-  }
-});
-
-tplGet.addEventListener('click', async () => {
-  try {
-    ensureSDK();
-    const res = await sdk.templates.get(tplId.value.trim());
-    toastOK(miscOut, res);
-  } catch (e) {
-    toastERR(miscOut, e);
-  }
-});
-
 getSettings.addEventListener('click', async () => {
   try {
     ensureSDK();
@@ -271,7 +259,7 @@ getSettings.addEventListener('click', async () => {
     try { loadServices.click(); } catch {}
     try { refreshSel.click(); } catch {}
     try { listDocs.click(); } catch {}
-    try { tplList.click(); } catch {}
+    try { loadTemplates.click(); } catch {}
     try { getSettings.click(); } catch {}
   } catch (e) {
     // non-fatal

--- a/static/app/js/main.js
+++ b/static/app/js/main.js
@@ -61,7 +61,6 @@ const tplSel = $('tplSel');
 const tplCard = $('tplCard');
 const userId = $('userId');
 const getSettings = $('getSettings');
-const miscOut = $('miscOut');
 
 const manageServices = $('manageServices');
 const newSvcProvider = $('newSvcProvider');
@@ -283,9 +282,9 @@ getSettings.addEventListener('click', async () => {
   try {
     ensureSDK();
     const res = await sdk.settings.get(userId.value || 'local-user');
-    toastOK(miscOut, res);
+    console.log(res);
   } catch (e) {
-    toastERR(miscOut, e);
+    console.error(e);
   }
 });
 

--- a/static/app/js/main.js
+++ b/static/app/js/main.js
@@ -3,6 +3,7 @@ import { setupLLMServiceUI } from './llm_service.js';
 import { setupChatUI } from './chat.js';
 import { setupDocumentsUI } from './documents.js';
 import { setupPromptTemplatesUI } from './prompt_templates.js';
+import { setupLLMServiceAdminUI } from './llm_service_admin.js';
 import { initWindows } from '../../ui/js/windows.js';
 
 const $ = (id) => document.getElementById(id);
@@ -62,7 +63,28 @@ const userId = $('userId');
 const getSettings = $('getSettings');
 const miscOut = $('miscOut');
 
+const manageServices = $('manageServices');
+const newSvcProvider = $('newSvcProvider');
+const newSvcBaseUrl = $('newSvcBaseUrl');
+const newSvcAuth = $('newSvcAuth');
+const delSvcId = $('delSvcId');
+const modelSvcId = $('modelSvcId');
+const modelName = $('modelName');
+const modelModality = $('modelModality');
+const delModelId = $('delModelId');
+const createSvc = $('createSvc');
+const deleteSvc = $('deleteSvc');
+const createModel = $('createModel');
+const deleteModel = $('deleteModel');
+const svcAdminOut = $('svcAdminOut');
+
 initWindows({ menuId: 'windowMenu', containerId: 'desktop' });
+
+const svcAdminWin = document.querySelector('.window[data-id="service-admin"]');
+if (svcAdminWin) svcAdminWin.style.display = 'none';
+manageServices.addEventListener('click', () => {
+  if (svcAdminWin) svcAdminWin.style.display = 'block';
+});
 
 // ---- state ----
 let sdk = null;
@@ -180,6 +202,27 @@ setupPromptTemplatesUI({
   getSDK: () => sdk,
   elements: { loadTemplates, tplSel, tplCard, templateId },
   helpers: { ensureSDK }
+});
+
+// ---- service admin ----
+setupLLMServiceAdminUI({
+  getSDK: () => sdk,
+  elements: {
+    createSvc,
+    deleteSvc,
+    createModel,
+    deleteModel,
+    newSvcProvider,
+    newSvcBaseUrl,
+    newSvcAuth,
+    delSvcId,
+    modelSvcId,
+    modelName,
+    modelModality,
+    delModelId,
+    out: svcAdminOut
+  },
+  helpers: { ensureSDK, setBusy, toastOK, toastERR }
 });
 
 // ---- ingest ----

--- a/static/app/js/prompt_template_item.js
+++ b/static/app/js/prompt_template_item.js
@@ -4,32 +4,11 @@ import { renderWithModes } from "/static/ui/js/render.js";
 export function createPromptTemplateSchema({
   sdk,
   onSelect,
-  onSave,
-  onEdit,
-  onCancel
+  onSave
 } = {}) {
   return {
     modes: {
       default: {
-        elements: {
-          name:        { type: 'text', format: 'title' },
-          description: { type: 'text' },
-          created_at:  { type: 'date', format: 'MM/DD/YYYY HH:mm:SS' }
-        },
-        order: ['name','description','created_at'],
-        actions: [
-          {
-            id: 'select', label: 'Select', variant: 'primary',
-            onAction: async (values, ctx) => { await onSelect?.(values, ctx); }
-          },
-          {
-            id: 'edit', label: 'Edit', variant: 'secondary',
-            onAction: (values, ctx) => { onEdit?.(values, ctx); ctx.setMode('edit'); }
-          }
-        ]
-      },
-      edit: {
-        extends: 'default',
         elements: {
           id:          { type: 'text', input: { disabled: true } },
           name:        { type: 'text', format: 'title', input: {} },
@@ -43,8 +22,11 @@ export function createPromptTemplateSchema({
         },
         order: ['id','name','description','system','content','inputs','meta','user_format','created_at'],
         use_inputs: true,
-        actions_replace: true,
         actions: [
+          {
+            id: 'select', label: 'Select', variant: 'secondary',
+            onAction: async (values, ctx) => { await onSelect?.(values, ctx); }
+          },
           {
             id: 'save', label: 'Save', variant: 'primary',
             onAction: async (values, ctx) => {
@@ -52,13 +34,8 @@ export function createPromptTemplateSchema({
               delete patch.id;
               delete patch.created_at;
               await sdk?.templates?.put(values.id, patch);
-              await onSave?.(patch, ctx);
-              ctx.setMode('default');
+              await onSave?.(values, ctx);
             }
-          },
-          {
-            id: 'cancel', label: 'Cancel', variant: 'secondary',
-            onAction: (values, ctx) => { onCancel?.(values, ctx); ctx.setMode('default'); }
           }
         ]
       }

--- a/static/app/js/prompt_template_item.js
+++ b/static/app/js/prompt_template_item.js
@@ -12,14 +12,11 @@ export function createPromptTemplateSchema({
     modes: {
       default: {
         elements: {
-          id:          { type: 'text', format: 'mono' },
           name:        { type: 'text', format: 'title' },
           description: { type: 'text' },
-          template:    { type: 'text', input: { type: 'textarea', rows: 6 } },
-          body:        { type: 'text', input: { type: 'textarea', rows: 6 } },
           created_at:  { type: 'date', format: 'MM/DD/YYYY HH:mm:SS' }
         },
-        order: ['name','description','template','body','created_at'],
+        order: ['name','description','created_at'],
         actions: [
           {
             id: 'select', label: 'Select', variant: 'primary',
@@ -33,6 +30,11 @@ export function createPromptTemplateSchema({
       },
       edit: {
         extends: 'default',
+        elements: {
+          template: { type: 'text', input: { type: 'textarea', rows: 6 } },
+          body:     { type: 'text', input: { type: 'textarea', rows: 6 } }
+        },
+        order: ['name','description','template','body','created_at'],
         use_inputs: true,
         actions_replace: true,
         actions: [

--- a/static/app/js/prompt_template_item.js
+++ b/static/app/js/prompt_template_item.js
@@ -31,10 +31,17 @@ export function createPromptTemplateSchema({
       edit: {
         extends: 'default',
         elements: {
-          template: { type: 'text', input: { type: 'textarea', rows: 6 } },
-          body:     { type: 'text', input: { type: 'textarea', rows: 6 } }
+          id:          { type: 'text', input: { disabled: true } },
+          name:        { type: 'text', format: 'title', input: {} },
+          description: { type: 'text', input: { type: 'textarea', rows: 2 } },
+          system:      { type: 'text', input: { type: 'textarea', rows: 3 } },
+          content:     { type: 'text', input: { type: 'textarea', rows: 6 } },
+          inputs:      { type: 'json', input: { type: 'textarea', rows: 3 } },
+          meta:        { type: 'json', input: { type: 'textarea', rows: 3 } },
+          user_format: { type: 'text', input: {} },
+          created_at:  { type: 'date', format: 'MM/DD/YYYY HH:mm:SS', input: { disabled: true } }
         },
-        order: ['name','description','template','body','created_at'],
+        order: ['id','name','description','system','content','inputs','meta','user_format','created_at'],
         use_inputs: true,
         actions_replace: true,
         actions: [

--- a/static/app/js/prompt_template_item.js
+++ b/static/app/js/prompt_template_item.js
@@ -1,0 +1,63 @@
+// prompt_template_item.js
+import { renderWithModes } from "/static/ui/js/render.js";
+
+export function createPromptTemplateSchema({
+  sdk,
+  onSelect,
+  onSave,
+  onEdit,
+  onCancel
+} = {}) {
+  return {
+    modes: {
+      default: {
+        elements: {
+          id:          { type: 'text', format: 'mono' },
+          name:        { type: 'text', format: 'title' },
+          description: { type: 'text' },
+          template:    { type: 'text', input: { type: 'textarea', rows: 6 } },
+          body:        { type: 'text', input: { type: 'textarea', rows: 6 } },
+          created_at:  { type: 'date', format: 'MM/DD/YYYY HH:mm:SS' }
+        },
+        order: ['name','description','template','body','created_at'],
+        actions: [
+          {
+            id: 'select', label: 'Select', variant: 'primary',
+            onAction: async (values, ctx) => { await onSelect?.(values, ctx); }
+          },
+          {
+            id: 'edit', label: 'Edit', variant: 'secondary',
+            onAction: (values, ctx) => { onEdit?.(values, ctx); ctx.setMode('edit'); }
+          }
+        ]
+      },
+      edit: {
+        extends: 'default',
+        use_inputs: true,
+        actions_replace: true,
+        actions: [
+          {
+            id: 'save', label: 'Save', variant: 'primary',
+            onAction: async (values, ctx) => {
+              const patch = { ...values };
+              delete patch.id;
+              delete patch.created_at;
+              await sdk?.templates?.put(values.id, patch);
+              await onSave?.(patch, ctx);
+              ctx.setMode('default');
+            }
+          },
+          {
+            id: 'cancel', label: 'Cancel', variant: 'secondary',
+            onAction: (values, ctx) => { onCancel?.(values, ctx); ctx.setMode('default'); }
+          }
+        ]
+      }
+    }
+  };
+}
+
+export function renderTemplateCard(tpl, deps = {}, opts = {}) {
+  const schema = createPromptTemplateSchema(deps);
+  return renderWithModes(tpl, schema, { mode: opts.mode || 'default' });
+}

--- a/static/app/js/prompt_templates.js
+++ b/static/app/js/prompt_templates.js
@@ -12,7 +12,11 @@ export function setupPromptTemplatesUI({ getSDK, elements, helpers }) {
     if (!tpl) return;
     const host = renderTemplateCard(tpl, {
       sdk: getSDK(),
-      onSelect: (values) => { if (templateId) templateId.value = values.id; }
+      onSelect: (values) => { if (templateId) templateId.value = values.id; },
+      onSave: (values) => {
+        const current = templates.get(values.id) || {};
+        templates.set(values.id, { ...current, ...values });
+      }
     });
     tplCard.appendChild(host);
   }

--- a/static/app/js/prompt_templates.js
+++ b/static/app/js/prompt_templates.js
@@ -1,0 +1,49 @@
+import { renderTemplateCard } from './prompt_template_item.js';
+
+export function setupPromptTemplatesUI({ getSDK, elements, helpers }) {
+  const { loadTemplates, tplSel, tplCard, templateId } = elements;
+  const { ensureSDK } = helpers;
+
+  const templates = new Map();
+
+  function renderTemplate(id) {
+    tplCard.innerHTML = '';
+    const tpl = templates.get(id);
+    if (!tpl) return;
+    const host = renderTemplateCard(tpl, {
+      sdk: getSDK(),
+      onSelect: (values) => { if (templateId) templateId.value = values.id; }
+    });
+    tplCard.appendChild(host);
+  }
+
+  async function fetchTemplates() {
+    try {
+      ensureSDK();
+      const sdk = getSDK();
+      const list = await sdk.templates.list();
+      templates.clear();
+      tplSel.innerHTML = '';
+      const def = document.createElement('option');
+      def.value = '';
+      def.textContent = '-- select template --';
+      tplSel.appendChild(def);
+      for (const t of list) {
+        templates.set(t.id, t);
+        const opt = document.createElement('option');
+        opt.value = t.id;
+        opt.textContent = t.id;
+        tplSel.appendChild(opt);
+      }
+      if (list.length) {
+        tplSel.value = list[0].id;
+        renderTemplate(list[0].id);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  loadTemplates.addEventListener('click', fetchTemplates);
+  tplSel.addEventListener('change', () => renderTemplate(tplSel.value));
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -155,7 +155,6 @@
           <input id="userId" value="local-user" />
           <button id="getSettings">Get Settings</button>
         </div>
-        <pre id="miscOut" class="mono" style="max-height:200px;"></pre>
       </section>
 
   </main>

--- a/templates/index.html
+++ b/templates/index.html
@@ -150,11 +150,11 @@
           <button id="loadTemplates">Load Templates</button>
           <select id="tplSel"></select>
         </div>
-        <div id="tplCard"></div>
         <div class="row">
           <input id="userId" value="local-user" />
           <button id="getSettings">Get Settings</button>
         </div>
+        <div id="tplCard"></div>
       </section>
 
   </main>

--- a/templates/index.html
+++ b/templates/index.html
@@ -121,10 +121,10 @@
       <section id="win-templates" data-win="templates" data-title="Templates & Settings">
         <h2>Templates & Settings</h2>
         <div class="row">
-          <button id="tplList">List Templates</button>
-          <input id="tplId" placeholder="template id…" />
-          <button id="tplGet">Get</button>
+          <button id="loadTemplates">Load Templates</button>
+          <select id="tplSel"></select>
         </div>
+        <div id="tplCard"></div>
         <div class="row">
           <input id="userId" value="local-user" />
           <button id="getSettings">Get Settings</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,6 +28,7 @@
         <div class="row">
           <button id="loadServices">Load Services</button>
           <button id="refreshSelection">Get Selection</button>
+          <button id="manageServices">Manage Services</button>
         </div>
         <div class="row">
           <label style="min-width:80px;">Service</label>
@@ -43,6 +44,31 @@
         <div id="serviceLst"></div>
         <div id="serviceCards"></div>
         <div id="modelCards"></div>
+      </section>
+
+      <section id="win-service-admin" data-win="service-admin" data-title="LLM Service Admin">
+        <h2>LLM Service Admin</h2>
+        <div class="row">
+          <input id="newSvcProvider" placeholder="provider" />
+          <input id="newSvcBaseUrl" placeholder="base URL" />
+          <input id="newSvcAuth" placeholder="auth ref" />
+          <button id="createSvc">Create Service</button>
+        </div>
+        <div class="row">
+          <input id="delSvcId" placeholder="service id" />
+          <button id="deleteSvc">Delete Service</button>
+        </div>
+        <div class="row">
+          <input id="modelSvcId" placeholder="service id" />
+          <input id="modelName" placeholder="model name" />
+          <input id="modelModality" placeholder="modality" />
+          <button id="createModel">Add Model</button>
+        </div>
+        <div class="row">
+          <input id="delModelId" placeholder="model id" />
+          <button id="deleteModel">Delete Model</button>
+        </div>
+        <pre id="svcAdminOut" class="mono" style="max-height:200px;"></pre>
       </section>
 
       <section id="win-search" data-win="search" data-title="Search">


### PR DESCRIPTION
## Summary
- Populate LLM service and model dropdowns from API responses and render a single card for the current selections
- Add selectable/editable prompt template UI using dropdown and card components
- Integrate new prompt template interface into demo page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a543179600832c8270a39423c1bf1f