### PR TITLE
Refactor UI windows and chat controls

### DIFF
--- a/static/app/js/chat.js
+++ b/static/app/js/chat.js
@@ -1,5 +1,5 @@
-export function setupChatUI({ getSDK, ensureSession, getSessionId, elements, helpers }) {
-  const { persona, templateId, topK, msg, send, meta, chatOut, userId, svcSel, modelSel } = elements;
+export function setupChatUI({ getSDK, ensureSession, getSessionId, elements, helpers, getPersona }) {
+  const { templateId, topK, msg, send, meta, chatOut, userId, svcSel, modelSel } = elements;
   const { ensureSDK, setBusy } = helpers;
 
   function appendMessage(role, text) {
@@ -35,7 +35,7 @@ export function setupChatUI({ getSDK, ensureSession, getSessionId, elements, hel
         userId: userId.value || 'local-user',
         serviceId: svcSel.value || undefined,
         modelId: modelSel.value || undefined,
-        persona: persona.value || '',
+        persona: (typeof getPersona === 'function' ? getPersona() : '') || '',
         templateId: templateId.value || 'rag_chat',
         topK: Number(topK.value) || 8,
         onMeta: (m) => { meta.textContent = `meta: ${typeof m === 'string' ? m : JSON.stringify(m)}`; },

--- a/static/app/js/chat.js
+++ b/static/app/js/chat.js
@@ -1,5 +1,5 @@
 export function setupChatUI({ getSDK, ensureSession, getSessionId, elements, helpers }) {
-  const { persona, templateId, topK, msg, send, stream, meta, chatOut, userId, svcSel, modelSel } = elements;
+  const { persona, templateId, topK, msg, send, meta, chatOut, userId, svcSel, modelSel } = elements;
   const { ensureSDK, setBusy } = helpers;
 
   function appendMessage(role, text) {
@@ -28,35 +28,6 @@ export function setupChatUI({ getSDK, ensureSession, getSessionId, elements, hel
       const userText = msg.value;
       appendMessage('user', userText);
       msg.value = '';
-      const res = await sdk.chat.send({
-        message: userText,
-        sessionId: getSessionId(),
-        userId: userId.value || 'local-user',
-        serviceId: svcSel.value || undefined,
-        modelId: modelSel.value || undefined,
-        persona: persona.value || '',
-        templateId: templateId.value || 'rag_chat',
-        topK: Number(topK.value) || 8
-      });
-      appendMessage('bot', res.response);
-    } catch (e) {
-      appendMessage('bot', e?.message || String(e));
-    } finally {
-      setBusy(send, false);
-    }
-  });
-
-  stream.addEventListener('click', async () => {
-    try {
-      ensureSDK();
-      const sdk = getSDK();
-      setBusy(stream, true);
-      await ensureSession();
-      meta.textContent = '';
-      const userText = msg.value;
-      appendMessage('user', userText);
-      msg.value = '';
-      const controller = new AbortController();
       const botDiv = appendMessage('bot', '');
       const p = {
         message: userText,
@@ -67,7 +38,6 @@ export function setupChatUI({ getSDK, ensureSession, getSessionId, elements, hel
         persona: persona.value || '',
         templateId: templateId.value || 'rag_chat',
         topK: Number(topK.value) || 8,
-        signal: controller.signal,
         onMeta: (m) => { meta.textContent = `meta: ${typeof m === 'string' ? m : JSON.stringify(m)}`; },
         onToken: (t) => { botDiv.textContent += t; chatOut.scrollTop = chatOut.scrollHeight; },
         onDone: (final) => {
@@ -81,7 +51,7 @@ export function setupChatUI({ getSDK, ensureSession, getSessionId, elements, hel
     } catch (e) {
       appendMessage('bot', e?.message || String(e));
     } finally {
-      setBusy(stream, false);
+      setBusy(send, false);
     }
   });
 }

--- a/static/app/js/chat.js
+++ b/static/app/js/chat.js
@@ -1,6 +1,6 @@
 export function setupChatUI({ getSDK, ensureSession, getSessionId, elements, helpers }) {
-  const { persona, templateId, chatTopK, inactive, msg, send, stream, meta, chatOut, userId, svcSel, modelSel } = elements;
-  const { ensureSDK, setBusy, safeParse } = helpers;
+  const { persona, templateId, topK, msg, send, stream, meta, chatOut, userId, svcSel, modelSel } = elements;
+  const { ensureSDK, setBusy } = helpers;
 
   function appendMessage(role, text) {
     const div = document.createElement('div');
@@ -10,6 +10,13 @@ export function setupChatUI({ getSDK, ensureSession, getSessionId, elements, hel
     chatOut.scrollTop = chatOut.scrollHeight;
     return div;
   }
+
+  msg.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      send.click();
+    }
+  });
 
   send.addEventListener('click', async () => {
     try {
@@ -29,8 +36,7 @@ export function setupChatUI({ getSDK, ensureSession, getSessionId, elements, hel
         modelId: modelSel.value || undefined,
         persona: persona.value || '',
         templateId: templateId.value || 'rag_chat',
-        topK: Number(chatTopK.value) || 8,
-        inactive: safeParse(inactive.value, undefined)
+        topK: Number(topK.value) || 8
       });
       appendMessage('bot', res.response);
     } catch (e) {
@@ -60,8 +66,7 @@ export function setupChatUI({ getSDK, ensureSession, getSessionId, elements, hel
         modelId: modelSel.value || undefined,
         persona: persona.value || '',
         templateId: templateId.value || 'rag_chat',
-        topK: Number(chatTopK.value) || 8,
-        inactive: safeParse(inactive.value, undefined),
+        topK: Number(topK.value) || 8,
         signal: controller.signal,
         onMeta: (m) => { meta.textContent = `meta: ${typeof m === 'string' ? m : JSON.stringify(m)}`; },
         onToken: (t) => { botDiv.textContent += t; chatOut.scrollTop = chatOut.scrollHeight; },

--- a/static/app/js/chat_history.js
+++ b/static/app/js/chat_history.js
@@ -1,0 +1,34 @@
+export function setupChatHistoryUI({ getSDK, setSession, renderHistory, elements, helpers }) {
+  const { listSessions, sessionList } = elements;
+  const { ensureSDK, setBusy, toastERR } = helpers;
+
+  listSessions.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      const sdk = getSDK();
+      setBusy(listSessions, true);
+      const res = await sdk.sessions.list();
+      sessionList.innerHTML = '';
+      (res || []).forEach(sess => {
+        const item = document.createElement('div');
+        item.className = 'item';
+        item.textContent = sess.title || sess.session_id;
+        item.addEventListener('click', async () => {
+          try {
+            ensureSDK();
+            const s = await sdk.sessions.get(sess.session_id);
+            setSession(s.session_id);
+            renderHistory(s);
+          } catch (e) {
+            toastERR(sessionList, e);
+          }
+        });
+        sessionList.appendChild(item);
+      });
+    } catch (e) {
+      toastERR(sessionList, e);
+    } finally {
+      setBusy(listSessions, false);
+    }
+  });
+}

--- a/static/app/js/chat_history.js
+++ b/static/app/js/chat_history.js
@@ -1,5 +1,5 @@
 export function setupChatHistoryUI({ getSDK, setSession, renderHistory, elements, helpers }) {
-  const { sessionList, newChat } = elements;
+  const { sessionList,listSessions, newChat } = elements;
   const { ensureSDK, setBusy, toastERR } = helpers;
 
   async function loadSessions() {
@@ -27,6 +27,36 @@ export function setupChatHistoryUI({ getSDK, setSession, renderHistory, elements
       toastERR(sessionList, e);
     }
   }
+
+  listSessions.addEventListener('click', async () => {
+    try {
+      ensureSDK();
+      const sdk = getSDK();
+      setBusy(listSessions, true);
+      const res = await sdk.sessions.list();
+      sessionList.innerHTML = '';
+      (res || []).forEach(sess => {
+        const item = document.createElement('div');
+        item.className = 'item';
+        item.textContent = sess.title || sess.session_id;
+        item.addEventListener('click', async () => {
+          try {
+            ensureSDK();
+            const s = await sdk.sessions.get(sess.session_id);
+            setSession(s.session_id);
+            renderHistory(s);
+          } catch (e) {
+            toastERR(sessionList, e);
+          }
+        });
+        sessionList.appendChild(item);
+      });
+    } catch (e) {
+      toastERR(sessionList, e);
+    } finally {
+      setBusy(listSessions, false);
+    }
+  });
 
   newChat.addEventListener('click', async () => {
     try {

--- a/static/app/js/main.js
+++ b/static/app/js/main.js
@@ -32,6 +32,7 @@ const doSearch = $('doSearch');
 const searchOut = $('searchOut');
 
 const newChat = $('newChat');
+const listSessions = $('listSessions');
 const sessionList = $('sessionList');
 
 const listDocs = $('listDocs');
@@ -262,7 +263,7 @@ setupChatHistoryUI({
     });
     chatOut.scrollTop = chatOut.scrollHeight;
   },
-  elements: { sessionList, newChat },
+  elements: { sessionList, listSessions, newChat },
   helpers: { ensureSDK, setBusy, toastERR }
 });
 

--- a/static/app/js/main.js
+++ b/static/app/js/main.js
@@ -8,7 +8,6 @@ import { initWindows } from '../../ui/js/windows.js';
 
 const $ = (id) => document.getElementById(id);
 const j = (o) => JSON.stringify(o, null, 2);
-const safeParse = (s, fallback) => { try { return JSON.parse(s); } catch { return fallback; } };
 
 // ---- elements ----
 const base    = $('base');
@@ -40,8 +39,6 @@ const segView = $('segView');
 
 const persona = $('persona');
 const templateId = $('templateId');
-const chatTopK = $('chatTopK');
-const inactive = $('inactive');
 const msg = $('msg');
 const send = $('send');
 const stream = $('stream');
@@ -172,8 +169,7 @@ ensure.addEventListener('click', async () => {
 // ---- search ----
 doSearch.addEventListener('click', sdkHandler(doSearch, searchOut, () => sdk.search.run({
   q: q.value,
-  topK: Number(topK.value) || 5,
-  inactive: safeParse(inactive.value, undefined)
+  topK: Number(topK.value) || 5
 })));
 
 // ---- documents & segments ----
@@ -188,8 +184,8 @@ setupChatUI({
   getSDK: () => sdk,
   ensureSession,
   getSessionId: () => sessionId,
-  elements: { persona, templateId, chatTopK, inactive, msg, send, stream, meta, chatOut, userId, svcSel, modelSel },
-  helpers: { ensureSDK, setBusy, safeParse }
+  elements: { persona, templateId, topK, msg, send, stream, meta, chatOut, userId, svcSel, modelSel },
+  helpers: { ensureSDK, setBusy }
 });
 
 // ---- services/models ----

--- a/static/app/js/main.js
+++ b/static/app/js/main.js
@@ -41,7 +41,6 @@ const persona = $('persona');
 const templateId = $('templateId');
 const msg = $('msg');
 const send = $('send');
-const stream = $('stream');
 const meta = $('meta');
 const chatOut = $('chatOut');
 
@@ -74,7 +73,7 @@ const createModel = $('createModel');
 const deleteModel = $('deleteModel');
 const svcAdminOut = $('svcAdminOut');
 
-initWindows({ menuId: 'windowMenu', containerId: 'desktop' });
+initWindows({ menuId: 'windowMenu', menuBtnId: 'windowMenuBtn', containerId: 'desktop' });
 
 const svcAdminWin = document.querySelector('.window[data-id="service-admin"]');
 if (svcAdminWin) svcAdminWin.style.display = 'none';
@@ -184,7 +183,7 @@ setupChatUI({
   getSDK: () => sdk,
   ensureSession,
   getSessionId: () => sessionId,
-  elements: { persona, templateId, topK, msg, send, stream, meta, chatOut, userId, svcSel, modelSel },
+  elements: { persona, templateId, topK, msg, send, meta, chatOut, userId, svcSel, modelSel },
   helpers: { ensureSDK, setBusy }
 });
 

--- a/static/app/js/main.js
+++ b/static/app/js/main.js
@@ -39,6 +39,8 @@ const segs = $('segs');
 const segView = $('segView');
 
 const persona = $('persona');
+const savePersona = $('savePersona');
+const cancelPersona = $('cancelPersona');
 const templateId = $('templateId');
 const msg = $('msg');
 const send = $('send');
@@ -203,12 +205,28 @@ setupDocumentsUI({
 });
 
 // ---- chat ----
+let personaText = '';
+try { personaText = localStorage.getItem('personaText') || ''; } catch {}
+persona.value = personaText;
+savePersona.addEventListener('click', () => {
+  personaText = persona.value;
+  try { localStorage.setItem('personaText', personaText); } catch {}
+  const w = document.querySelector('.window[data-id="persona"]');
+  if (w) w.style.display = 'none';
+});
+cancelPersona.addEventListener('click', () => {
+  persona.value = personaText;
+  const w = document.querySelector('.window[data-id="persona"]');
+  if (w) w.style.display = 'none';
+});
+
 setupChatUI({
   getSDK: () => sdk,
   ensureSession,
   getSessionId: () => sessionId,
-  elements: { persona, templateId, topK, msg, send, meta, chatOut, userId, svcSel, modelSel },
-  helpers: { ensureSDK, setBusy }
+  elements: { templateId, topK, msg, send, meta, chatOut, userId, svcSel, modelSel },
+  helpers: { ensureSDK, setBusy },
+  getPersona: () => personaText
 });
 
 // ---- services/models ----

--- a/static/app/js/main.js
+++ b/static/app/js/main.js
@@ -31,7 +31,7 @@ const topK = $('topK');
 const doSearch = $('doSearch');
 const searchOut = $('searchOut');
 
-const listSessions = $('listSessions');
+const newChat = $('newChat');
 const sessionList = $('sessionList');
 
 const listDocs = $('listDocs');
@@ -147,6 +147,7 @@ initBtn.addEventListener('click', () => {
     sdk = new DKClient({ baseUrl: base.value });
     window.sdk = sdk;
     console.log('SDK ready.');
+    document.dispatchEvent(new Event('dk-sdk-ready'));
   } catch (e) {
     console.error(e);
   }
@@ -261,7 +262,7 @@ setupChatHistoryUI({
     });
     chatOut.scrollTop = chatOut.scrollHeight;
   },
-  elements: { listSessions, sessionList },
+  elements: { sessionList, newChat },
   helpers: { ensureSDK, setBusy, toastERR }
 });
 

--- a/static/app/js/sdk.js
+++ b/static/app/js/sdk.js
@@ -295,8 +295,14 @@ export class DKClient {
           try { finalMeta = JSON.parse(data); } catch { finalMeta = data; }
           onMeta?.(finalMeta);
         } else if (event === "delta") {
-          finalText += data;
-          onToken?.(data);
+          let token = data;
+          try {
+            const parsed = JSON.parse(data);
+            if (typeof parsed === 'string') token = parsed;
+            else if (parsed?.delta) token = parsed.delta;
+          } catch {}
+          finalText += token;
+          onToken?.(token);
         } else if (event === "done") {
           try {
             const obj = JSON.parse(data);

--- a/static/app/js/search_result_item.js
+++ b/static/app/js/search_result_item.js
@@ -1,0 +1,31 @@
+import { renderWithModes } from '/static/ui/js/render.js';
+import { enableClickToggle } from '/static/ui/js/dom.js';
+import { renderSegmentItem } from './segment_item.js';
+
+export function createSearchResultSchema(deps = {}) {
+  return {
+    modes: {
+      default: {
+        elements: {
+          text:        { type: 'text', format: 'title' },
+          source:      { type: 'text' },
+          document_id: { type: 'text' },
+          score:       { type: 'number' },
+          page:        { type: 'number' },
+          segment:     {
+            render: (seg) => seg ? renderSegmentItem(seg, deps.segmentDeps, { mode: 'mini' }) : document.createTextNode('')
+          }
+        },
+        order: ['text','source','document_id','score','page','segment']
+      }
+    }
+  };
+}
+
+export function renderSearchResultItem(res, deps = {}, opts = {}) {
+  const schema = createSearchResultSchema(deps);
+  const host = renderWithModes(res, schema, { mode: opts.mode || 'default' });
+  // allow toggle to collapse/expand
+  if (opts.clickToggle !== false) enableClickToggle(host);
+  return host;
+}

--- a/static/app/js/search_result_item.js
+++ b/static/app/js/search_result_item.js
@@ -13,7 +13,12 @@ export function createSearchResultSchema(deps = {}) {
           score:       { type: 'number' },
           page:        { type: 'number' },
           segment:     {
-            render: (seg) => seg ? renderSegmentItem(seg, deps.segmentDeps, { mode: 'mini' }) : document.createTextNode('')
+            render: (seg) => {
+              if (!seg) return document.createTextNode('');
+              const mini = { ...seg };
+              if (!mini.preview && mini.text) mini.preview = mini.text;
+              return renderSegmentItem(mini, deps.segmentDeps, { mode: 'mini' });
+            }
           }
         },
         order: ['text','source','document_id','score','page','segment']

--- a/static/ui/css/style.css
+++ b/static/ui/css/style.css
@@ -130,6 +130,7 @@ footer { padding:12px 16px; border-top:1px solid var(--border); font-size:12px; 
   border:1px solid var(--border);
   border-radius:8px;
   background:var(--input-bg);
+  min-height:0;
 }
 .chat-msg {
   max-width:80%;
@@ -140,9 +141,10 @@ footer { padding:12px 16px; border-top:1px solid var(--border); font-size:12px; 
 }
 .chat-msg--user { background:var(--accent); margin-left:auto; }
 .chat-msg--bot  { background:var(--panel-bg); margin-right:auto; }
-.chat-input { display:flex; flex-direction:column; gap:8px; }
+.chat-input { display:flex; flex-direction:column; gap:8px; flex-shrink:0; }
 .chat-input textarea { min-height:80px; resize:vertical; }
 .chat-ctrls { margin-bottom:8px; }
+[data-id="chat"] .window__body { overflow:hidden; }
 [data-id="persona"] textarea {
   flex:1;
   width:100%;

--- a/static/ui/css/style.css
+++ b/static/ui/css/style.css
@@ -25,9 +25,13 @@
   --err: #c62828;
  }
 body { margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto; background:var(--bg); color:var(--fg); }
-header { padding:14px 18px; border-bottom:1px solid var(--border); display:flex; gap:12px; align-items:center; }
+header { padding:14px 18px; border-bottom:1px solid var(--border); display:flex; gap:12px; align-items:center; position:relative; }
 header input, header button, header select { background:var(--input-bg); color:var(--fg); border:1px solid var(--input-border); border-radius:6px; padding:8px 10px; }
 header button { cursor:pointer; }
+header .menu-list { display:none; position:absolute; top:100%; left:18px; background:var(--panel-bg); border:1px solid var(--border); border-radius:8px; list-style:none; margin:4px 0 0 0; padding:4px 0; }
+header .menu-list.visible { display:block; }
+header .menu-list li { padding:4px 12px; white-space:nowrap; cursor:pointer; }
+header .menu-list li:hover { background:var(--input-bg); }
 main { position:relative; padding:16px; min-height:calc(100vh - 120px); overflow:hidden; }
 section { background:var(--panel-bg); border:1px solid var(--border); border-radius:10px; padding:12px; display:flex; flex-direction:column; gap:10px; }
 h2 { font-size:14px; font-weight:700; margin:0 0 4px 0; color:#b9c8dc; text-transform:uppercase; letter-spacing:0.06em; }
@@ -139,4 +143,5 @@ footer { padding:12px 16px; border-top:1px solid var(--border); font-size:12px; 
 .chat-input { display:flex; flex-direction:column; gap:8px; }
 .chat-input textarea { min-height:80px; resize:vertical; }
 .chat-ctrls { margin-bottom:8px; }
+#win-persona textarea { flex:1; width:100%; }
 

--- a/static/ui/css/style.css
+++ b/static/ui/css/style.css
@@ -143,5 +143,21 @@ footer { padding:12px 16px; border-top:1px solid var(--border); font-size:12px; 
 .chat-input { display:flex; flex-direction:column; gap:8px; }
 .chat-input textarea { min-height:80px; resize:vertical; }
 .chat-ctrls { margin-bottom:8px; }
-#win-persona textarea { flex:1; width:100%; }
+[data-id="persona"] textarea {
+  flex:1;
+  width:100%;
+  resize:none;
+  white-space:pre-wrap;
+  word-break:break-word;
+}
+[data-id="search"] #searchOut {
+  flex:1;
+  max-height:none;
+  min-height:0;
+}
+[data-id="search"] .obj-card__value,
+[data-id="search"] .obj-card__title {
+  white-space:pre-wrap;
+  word-break:break-word;
+}
 

--- a/static/ui/js/render.js
+++ b/static/ui/js/render.js
@@ -137,6 +137,8 @@ export function renderBySchema(data, spec = {}, opts = {}) {
       });
       inputCtrls.set(key, { get, set });
       valueNode = node;
+    } else if (typeof cfg.render === 'function') {
+      valueNode = cfg.render(state[key], cfg, { data: state, key });
     } else {
       valueNode = renderValue(state[key], cfg);
     }

--- a/static/ui/js/windows.js
+++ b/static/ui/js/windows.js
@@ -15,6 +15,15 @@ export function initWindows({ containerId = 'desktop', menuId = 'windowMenu', me
     w.focus();
   };
 
+  const defaults = [
+    { left: 40,  top: 40 },
+    { left: 360, top: 40 },
+    { left: 680, top: 40 },
+    { left: 40,  top: 300 },
+    { left: 360, top: 300 },
+    { left: 680, top: 300 },
+  ];
+
   function buildWindow(section, idx) {
     const id = section.dataset.win || `win-${idx}`;
     const title = section.dataset.title || section.querySelector('h2')?.textContent || id;
@@ -24,8 +33,9 @@ export function initWindows({ containerId = 'desktop', menuId = 'windowMenu', me
     wrap.dataset.id = id;
     wrap.tabIndex = 0;
     const saved = JSON.parse(localStorage.getItem(`win:${id}`) || '{}');
-    wrap.style.left = saved.left || `${40 + idx * 30}px`;
-    wrap.style.top = saved.top || `${40 + idx * 30}px`;
+    const def = defaults[idx] || { left: 40 + idx * 30, top: 40 + idx * 30 };
+    wrap.style.left = saved.left || `${def.left}px`;
+    wrap.style.top = saved.top || `${def.top}px`;
     if (saved.width) wrap.style.width = saved.width;
     if (saved.height) wrap.style.height = saved.height;
     if (saved.hidden) wrap.style.display = 'none';

--- a/static/ui/js/windows.js
+++ b/static/ui/js/windows.js
@@ -1,15 +1,12 @@
-export function initWindows({ containerId = 'desktop', menuId = 'windowMenu' } = {}) {
+export function initWindows({ containerId = 'desktop', menuId = 'windowMenu', menuBtnId = 'windowMenuBtn' } = {}) {
   const container = document.getElementById(containerId) || document.body;
   const menu = document.getElementById(menuId);
+  const menuBtn = document.getElementById(menuBtnId);
   const registry = new Map();
   let zTop = 1;
 
   if (menu) {
     menu.innerHTML = '';
-    const placeholder = document.createElement('option');
-    placeholder.value = '';
-    placeholder.textContent = 'Windows…';
-    menu.appendChild(placeholder);
   }
 
   const bringToFront = (w) => {
@@ -150,24 +147,24 @@ export function initWindows({ containerId = 'desktop', menuId = 'windowMenu' } =
     clamp();
 
     if (menu) {
-      const opt = document.createElement('option');
-      opt.value = id;
-      opt.textContent = title;
-      menu.appendChild(opt);
+      const li = document.createElement('li');
+      li.textContent = title;
+      li.addEventListener('click', () => {
+        wrap.style.display = 'block';
+        bringToFront(wrap);
+        menu.classList.remove('visible');
+      });
+      menu.appendChild(li);
     }
   }
 
   document.querySelectorAll('section[data-win]').forEach((s, idx) => buildWindow(s, idx));
 
-  if (menu) {
-    menu.addEventListener('change', () => {
-      const id = menu.value;
-      const win = registry.get(id);
-      if (win) {
-        win.style.display = 'block';
-        bringToFront(win);
-      }
-      menu.value = '';
+  if (menu && menuBtn) {
+    menuBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      menu.classList.toggle('visible');
     });
+    document.addEventListener('click', () => menu.classList.remove('visible'));
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -119,7 +119,7 @@
       <section id="win-history" data-win="history" data-title="Chat History">
         <h2>Chat History</h2>
         <div class="row">
-          <button id="listSessions">List Sessions</button>
+          <button id="newChat">New Chat</button>
         </div>
         <div id="sessionList" class="list"></div>
       </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -116,6 +116,14 @@
         </div>
       </section>
 
+      <section id="win-history" data-win="history" data-title="Chat History">
+        <h2>Chat History</h2>
+        <div class="row">
+          <button id="listSessions">List Sessions</button>
+        </div>
+        <div id="sessionList" class="list"></div>
+      </section>
+
       <section id="win-persona" data-win="persona" data-title="Persona">
         <h2>Persona</h2>
         <div class="row">

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,13 +10,6 @@
 </head>
 <body>
   <header>
-    <strong>DKClient Demo</strong>
-    <span class="pill">browser only</span>
-    <input id="base" size="42" />
-    <button id="init">Init SDK</button>
-    <button id="prime">Prime User Session</button>
-    <button id="ensure">Ensure Session</button>
-    <span id="sid" class="mono subtle"></span>
     <select id="windowMenu">
       <option value="">Windows…</option>
     </select>
@@ -75,14 +68,26 @@
         <h2>Search</h2>
         <div class="row">
           <input id="q" placeholder="query…" />
+          <label>Top K</label>
           <input id="topK" type="number" value="5" style="max-width:80px;" />
           <button id="doSearch">Run</button>
         </div>
         <pre id="searchOut" class="mono" style="max-height:220px;"></pre>
       </section>
 
-      <section id="win-docs" data-win="documents" data-title="Documents & Segments">
-        <h2>Documents & Segments</h2>
+      <section id="win-docs" data-win="documents" data-title="Documents">
+        <h2>Documents</h2>
+        <div class="row">
+          <input id="files" type="file" multiple />
+          <button id="upload">Upload</button>
+          <button id="ingestAll">Ingest All</button>
+        </div>
+        <div class="row">
+          <input id="removeSource" placeholder="source name to remove…" />
+          <button id="remove">Remove Source</button>
+          <button id="clearDb">Clear DB</button>
+        </div>
+        <pre id="ingOut" class="mono" style="max-height:160px;"></pre>
         <div class="row">
           <button id="listDocs">List Documents</button>
           <span id="docCount" class="subtle"></span>
@@ -100,24 +105,6 @@
 
       <section id="win-chat" data-win="chat" data-title="Chat">
         <h2>Chat</h2>
-        <div class="grid-2 chat-ctrls">
-          <div>
-            <label>Persona</label>
-            <input id="persona" placeholder="optional persona tag" />
-          </div>
-          <div>
-            <label>Template ID</label>
-            <input id="templateId" value="rag_chat" />
-          </div>
-          <div>
-            <label>Top K</label>
-            <input id="chatTopK" type="number" value="8" />
-          </div>
-          <div>
-            <label>Inactive (JSON array of object_ids)</label>
-            <input id="inactive" placeholder='["obj_1","obj_2"]' />
-          </div>
-        </div>
         <div id="chatOut" class="chat-history"></div>
         <div class="chat-input">
           <textarea id="msg" placeholder="Ask your system something grounded…"></textarea>
@@ -129,26 +116,31 @@
         </div>
       </section>
 
-      <section id="win-ingest" data-win="ingest" data-title="Ingest">
-        <h2>Ingest</h2>
+      <section id="win-persona" data-win="persona" data-title="Persona">
+        <h2>Persona</h2>
         <div class="row">
-          <input id="files" type="file" multiple />
-          <button id="upload">Upload</button>
-          <button id="ingestAll">Ingest All</button>
+          <label>Persona</label>
+          <input id="persona" placeholder="optional persona tag" />
         </div>
-        <div class="row">
-          <input id="removeSource" placeholder="source name to remove…" />
-          <button id="remove">Remove Source</button>
-          <button id="clearDb">Clear DB</button>
-        </div>
-        <pre id="ingOut" class="mono" style="max-height:160px;"></pre>
       </section>
+
 
       <section id="win-templates" data-win="templates" data-title="Templates & Settings">
         <h2>Templates & Settings</h2>
         <div class="row">
+          <input id="base" size="42" />
+          <button id="init">Init SDK</button>
+          <button id="prime">Prime User Session</button>
+          <button id="ensure">Ensure Session</button>
+          <span id="sid" class="mono subtle"></span>
+        </div>
+        <div class="row">
           <button id="loadTemplates">Load Templates</button>
           <select id="tplSel"></select>
+        </div>
+        <div class="row">
+          <label>Template ID</label>
+          <input id="templateId" value="rag_chat" />
         </div>
         <div class="row">
           <input id="userId" value="local-user" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,9 +10,10 @@
 </head>
 <body>
   <header>
-    <select id="windowMenu">
-      <option value="">Windows…</option>
-    </select>
+    <div class="menu">
+      <button id="windowMenuBtn">Windows</button>
+      <ul id="windowMenu" class="menu-list"></ul>
+    </div>
   </header>
 
   <main id="desktop">
@@ -110,7 +111,6 @@
           <textarea id="msg" placeholder="Ask your system something grounded…"></textarea>
           <div class="row">
             <button id="send">Send</button>
-            <button id="stream">Stream</button>
             <span id="meta" class="subtle mono"></span>
           </div>
         </div>
@@ -118,10 +118,7 @@
 
       <section id="win-persona" data-win="persona" data-title="Persona">
         <h2>Persona</h2>
-        <div class="row">
-          <label>Persona</label>
-          <input id="persona" placeholder="optional persona tag" />
-        </div>
+        <textarea id="persona" placeholder="optional persona"></textarea>
       </section>
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -118,6 +118,10 @@
 
       <section id="win-persona" data-win="persona" data-title="Persona">
         <h2>Persona</h2>
+        <div class="row">
+          <button id="savePersona">Save</button>
+          <button id="cancelPersona">Cancel</button>
+        </div>
         <textarea id="persona" placeholder="optional persona"></textarea>
       </section>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -120,6 +120,7 @@
         <h2>Chat History</h2>
         <div class="row">
           <button id="newChat">New Chat</button>
+          <button id="listSessions">List Sessions</button>
         </div>
         <div id="sessionList" class="list"></div>
       </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -73,7 +73,7 @@
           <input id="topK" type="number" value="5" style="max-width:80px;" />
           <button id="doSearch">Run</button>
         </div>
-        <pre id="searchOut" class="mono" style="max-height:220px;"></pre>
+        <div id="searchOut" class="list"></div>
       </section>
 
       <section id="win-docs" data-win="documents" data-title="Documents">


### PR DESCRIPTION
## Summary
- Merge ingest controls into the documents window and add persona editor window
- Streamline header and chat UI; move template selection to Templates & Settings
- Send chat on Enter (Shift+Enter adds newline) and share Top K with search

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a59b5a8030832c80222e2671c5f5b0