### PR TITLE
Add layout menu for automatic window arrangement

### DIFF
--- a/static/app/js/main.js
+++ b/static/app/js/main.js
@@ -8,6 +8,7 @@ import { renderSearchResultItem } from './search_result_item.js';
 import { setupChatHistoryUI, historyWindow } from './chat_history.js';
 import { initWindows } from '../../ui/js/windows.js';
 import { layoutWindows, LayoutModes } from '../../ui/js/layout-windows.js';
+import { createMenu } from '../../ui/js/menu.js';
 
 const j = (o) => JSON.stringify(o, null, 2);
 
@@ -97,22 +98,16 @@ function applyLayout(mode) {
   });
 }
 
-const layoutMenu = document.getElementById('layoutMenu');
-const layoutMenuBtn = document.getElementById('layoutMenuBtn');
-if (layoutMenu && layoutMenuBtn) {
-  layoutMenuBtn.addEventListener('click', e => {
-    e.stopPropagation();
-    layoutMenu.classList.toggle('visible');
-  });
-  layoutMenu.addEventListener('click', e => {
-    const li = e.target.closest('li');
-    if (!li) return;
-    const action = li.dataset.action;
-    if (action) applyLayout(action);
-    layoutMenu.classList.remove('visible');
-  });
-  document.addEventListener('click', () => layoutMenu.classList.remove('visible'));
-}
+createMenu({
+  containerId: 'layoutMenu',
+  buttonText: 'Layout',
+  items: [
+    { label: 'Cascade', action: 'cascade' },
+    { label: 'Tile', action: 'tile' },
+    { label: 'Smart Layout', action: 'smart' },
+  ],
+  onSelect: applyLayout,
+});
 
 function openChat() {
   showWindow('chat');

--- a/static/app/js/main.js
+++ b/static/app/js/main.js
@@ -82,7 +82,10 @@ function applyLayout(mode) {
   });
   let layoutMode = LayoutModes.TILE;
   if (mode === 'cascade') layoutMode = LayoutModes.CASCADE;
+  if (mode === 'smarter') layoutMode = LayoutModes.MIN_RESIZE;
   else if (mode === 'smart') layoutMode = LayoutModes.SMART;
+  
+
   const layout = layoutWindows(ws, winData, layoutMode);
   layout.forEach(pos => {
     const w = windowRegistry.get(String(pos.id));
@@ -105,6 +108,7 @@ createMenu({
     { label: 'Cascade', action: 'cascade' },
     { label: 'Tile', action: 'tile' },
     { label: 'Smart Layout', action: 'smart' },
+    { label: 'Smarter Layout', action: 'smarter'}
   ],
   onSelect: applyLayout,
 });

--- a/static/ui/css/style.css
+++ b/static/ui/css/style.css
@@ -163,14 +163,6 @@ header { position: relative; z-index: 1000; }
 main#desktop { position: relative; z-index: 0; }
 
 header .menu { position: relative; }
-header .menu-list {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 1001;
-  display: none;
-}
-header .menu-list.visible { display: block; }
 header {
   padding: calc(var(--space-3) + 2px) var(--space-4);
   border-bottom: var(--border-w) solid var(--border);
@@ -196,7 +188,7 @@ header .menu-list {
   display: none;
   position: absolute;
   top: 100%;
-  left: var(--space-4);
+  left: 0;
   background: var(--panel-bg);
   border: var(--border-w) solid var(--border);
   border-radius: var(--radius-2);

--- a/static/ui/js/menu.js
+++ b/static/ui/js/menu.js
@@ -1,0 +1,34 @@
+export function createMenu({ containerId, buttonText, items = [], onSelect } = {}) {
+  const container = document.getElementById(containerId);
+  if (!container) return null;
+  container.classList.add('menu');
+
+  const btn = document.createElement('button');
+  btn.textContent = buttonText || '';
+  container.appendChild(btn);
+
+  const list = document.createElement('ul');
+  list.className = 'menu-list';
+  items.forEach(it => {
+    const li = document.createElement('li');
+    li.textContent = it.label || it.action;
+    if (it.action) li.dataset.action = it.action;
+    list.appendChild(li);
+  });
+  container.appendChild(list);
+
+  btn.addEventListener('click', e => {
+    e.stopPropagation();
+    list.classList.toggle('visible');
+  });
+
+  list.addEventListener('click', e => {
+    const li = e.target.closest('li');
+    if (!li) return;
+    list.classList.remove('visible');
+    if (onSelect) onSelect(li.dataset.action, li);
+  });
+
+  document.addEventListener('click', () => list.classList.remove('visible'));
+  return { button: btn, menu: list };
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,14 +14,7 @@
       <button id="windowMenuBtn">Windows</button>
       <ul id="windowMenu" class="menu-list"></ul>
     </div>
-    <div class="menu">
-      <button id="layoutMenuBtn">Layout</button>
-      <ul id="layoutMenu" class="menu-list">
-        <li data-action="cascade">Cascade</li>
-        <li data-action="tile">Tile</li>
-        <li data-action="smart">Smart Layout</li>
-      </ul>
-    </div>
+    <div id="layoutMenu" class="menu"></div>
   </header>
 
   <main id="desktop"></main>

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,14 @@
       <button id="windowMenuBtn">Windows</button>
       <ul id="windowMenu" class="menu-list"></ul>
     </div>
+    <div class="menu">
+      <button id="layoutMenuBtn">Layout</button>
+      <ul id="layoutMenu" class="menu-list">
+        <li data-action="cascade">Cascade</li>
+        <li data-action="tile">Tile</li>
+        <li data-action="smart">Smart Layout</li>
+      </ul>
+    </div>
   </header>
 
   <main id="desktop"></main>


### PR DESCRIPTION
## Summary
- Add header Layout menu with Cascade, Tile and Smart Layout options
- Wire menu to new layout-windows.js module to rearrange open windows automatically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7567a638c832c9a97e1c3983ed895