### PR TITLE
Make LLM model title fields editable

### DIFF
--- a/static/app/js/items/llm_service_model_item.js
+++ b/static/app/js/items/llm_service_model_item.js
@@ -61,6 +61,14 @@ export function createLLMServiceModelSchema({
 
       edit: {
         extends: "default",
+        // In edit mode the title fields should render as editable inputs
+        // rather than static header labels. Override the default element
+        // config to drop the `format: "title"` flag which the shared
+        // renderer treats as display-only.
+        elements: {
+          name:       { type: "text", input: { type: "text" } },
+          model_name: { type: "text", input: { type: "text" } }
+        },
         use_inputs: true,
         actions_replace: true, // ← clean swap: only Save/Cancel in edit mode
         actions: [


### PR DESCRIPTION
## Summary
- Allow editing of `name` and `model_name` in LLM service model cards by overriding the default title-only rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7db7cc01c832ca4343d49b3067d26